### PR TITLE
Group subtests into TeamCity suites

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,10 +31,10 @@ var (
 
 	additionalTestName = ""
 
-	run   = regexp.MustCompile("^=== RUN\\s+([a-zA-Z_]\\S*)")
-	end   = regexp.MustCompile("^(\\s*)--- (PASS|SKIP|FAIL):\\s+([a-zA-Z_]\\S*) \\((-?[\\.\\ds]+)\\)")
-	suite = regexp.MustCompile("^(ok|PASS|FAIL|exit status|Found)")
-	race  = regexp.MustCompile("^WARNING: DATA RACE")
+	run  = regexp.MustCompile("^=== RUN\\s+([a-zA-Z_]\\S*)")
+	end  = regexp.MustCompile("^(\\s*)--- (PASS|SKIP|FAIL):\\s+([a-zA-Z_]\\S*) \\((-?[\\.\\ds]+)\\)")
+	pkg  = regexp.MustCompile("^(ok|PASS|FAIL|exit status|Found)")
+	race = regexp.MustCompile("^WARNING: DATA RACE")
 )
 
 func init() {
@@ -100,9 +100,9 @@ func processReader(r *bufio.Reader, w io.Writer) {
 
 		runOut := run.FindStringSubmatch(line)
 		endOut := end.FindStringSubmatch(line)
-		suiteOut := suite.FindStringSubmatch(line)
+		pkgOut := pkg.FindStringSubmatch(line)
 
-		if test != nil && test.Status != "" && (runOut != nil || endOut != nil || suiteOut != nil) {
+		if test != nil && test.Status != "" && (runOut != nil || endOut != nil || pkgOut != nil) {
 			outputTest(w, test)
 			delete(tests, test.Name)
 			test = nil
@@ -126,7 +126,7 @@ func processReader(r *bufio.Reader, w io.Writer) {
 			prefix = endOut[1] + "\t"
 			test.Status = endOut[2]
 			test.Duration, _ = time.ParseDuration(endOut[4])
-		} else if suiteOut != nil {
+		} else if pkgOut != nil {
 			final += line
 		} else if test != nil && race.MatchString(line) {
 			test.Race = true

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ type Test struct {
 	Duration time.Duration
 	Status   string
 	Race     bool
+	Suite    bool
 }
 
 var (
@@ -87,9 +88,38 @@ func outputTest(w io.Writer, test *Test) {
 	}
 }
 
+func startSuite(w io.Writer, name string) {
+	fmt.Fprintf(w, "##teamcity[testSuiteStarted name='%s']\n", escape(name))
+}
+
+func finishSuite(w io.Writer, name string) {
+	fmt.Fprintf(w, "##teamcity[testSuiteFinished name='%s']\n", escape(name))
+}
+
+func suite(name string) string {
+	if idx := strings.LastIndex(name, "/"); idx != -1 {
+		return name[:idx]
+	}
+	return ""
+}
+
 func processReader(r *bufio.Reader, w io.Writer) {
-	tests := make(map[string]*Test)
+	tests := map[string]*Test{}
+	suites := []string{}
 	var test *Test
+	newTest := func(name string) *Test {
+		t := &Test{
+			Name:  name,
+			Start: getNow(),
+		}
+		tests[t.Name] = t
+		for n := suite(name); n != ""; n = suite(n) {
+			if p := tests[n]; p != nil {
+				p.Suite = true
+			}
+		}
+		return t
+	}
 	var final string
 	prefix := "\t"
 	for {
@@ -103,25 +133,27 @@ func processReader(r *bufio.Reader, w io.Writer) {
 		pkgOut := pkg.FindStringSubmatch(line)
 
 		if test != nil && test.Status != "" && (runOut != nil || endOut != nil || pkgOut != nil) {
+			for j := len(suites) - 1; j >= 0; j-- {
+				if !strings.HasPrefix(test.Name, suites[j]) {
+					finishSuite(w, suites[j])
+					suites = suites[:j]
+				}
+			}
+			if test.Suite {
+				startSuite(w, test.Name)
+				suites = append(suites, test.Name)
+			}
 			outputTest(w, test)
 			delete(tests, test.Name)
 			test = nil
 		}
 
 		if runOut != nil {
-			test = &Test{
-				Name:  runOut[1],
-				Start: getNow(),
-			}
-			tests[test.Name] = test
+			test = newTest(runOut[1])
 		} else if endOut != nil {
 			test = tests[endOut[3]]
 			if test == nil {
-				test = &Test{
-					Name:  endOut[3],
-					Start: getNow(),
-				}
-				tests[test.Name] = test
+				test = newTest(endOut[3])
 			}
 			prefix = endOut[1] + "\t"
 			test.Status = endOut[2]
@@ -143,6 +175,9 @@ func processReader(r *bufio.Reader, w io.Writer) {
 	if test != nil {
 		outputTest(w, test)
 		delete(tests, test.Name)
+	}
+	for j := len(suites) - 1; j >= 0; j-- {
+		finishSuite(w, suites[j])
 	}
 	for _, t := range tests {
 		outputTest(w, t)

--- a/testdata/input/subtest
+++ b/testdata/input/subtest
@@ -7,6 +7,7 @@
 === RUN   TestGDA/add/addx1004
 === RUN   TestGDA/add/addx1005
 === RUN   TestGDA/add/addx1006
+=== RUN   TestGDA/add/addx1006/subtest/name/with/slashes/in/it
 --- FAIL: TestGDA (0.13s)
     --- FAIL: TestGDA/add (0.13s)
         --- PASS: TestGDA/add/addx100 (0.00s)
@@ -70,6 +71,7 @@
         	gda_test.go:620: got: 1.524E-80 ({Coeff: 1524, Exponent: -83})
         	gda_test.go:639: unexpected result
         	gda_test.go:464: duration: 113.143µs
+		--- PASS: TestGDA/add/addx1006/subtest/name/with/slashes/in/it (0.01s)
 FAIL
 exit status 1
 FAIL	github.com/cockroachdb/apd	0.138s

--- a/testdata/output/quote
+++ b/testdata/output/quote
@@ -1,4 +1,5 @@
 I170222 16:43:32.465723 1 rand.go:76  Random seed: 7421160166306389396
+##teamcity[testSuiteStarted name='TestSimplifyExpr']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestSimplifyExpr' captureStandardOutput='true']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestSimplifyExpr' duration='10']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestSimplifyExpr/true~true' captureStandardOutput='true']
@@ -145,5 +146,6 @@ I170222 16:43:32.465723 1 rand.go:76  Random seed: 7421160166306389396
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestSimplifyExpr/((a_<_0)_AND_(a_<_0_AND_b_>_0))_OR_(a_>_1_AND_a_<_0)~(a_<_0)_AND_(b_>_0)' duration='0']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestSimplifyExpr/((a_<_0)_OR_(a_<_0_OR_b_>_0))_AND_(a_>_0_OR_a_<_1)~((a_<_0)_OR_(b_>_0))_AND_(a_IS_NOT_NULL)' captureStandardOutput='true']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestSimplifyExpr/((a_<_0)_OR_(a_<_0_OR_b_>_0))_AND_(a_>_0_OR_a_<_1)~((a_<_0)_OR_(b_>_0))_AND_(a_IS_NOT_NULL)' duration='0']
+##teamcity[testSuiteFinished name='TestSimplifyExpr']
 PASS
 ok      github.com/cockroachdb/cockroach/pkg/sql        0.062s

--- a/testdata/output/race
+++ b/testdata/output/race
@@ -4,6 +4,7 @@
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestConstBlah' duration='0']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestConstRace' captureStandardOutput='true']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestConstRace' duration='0']
+##teamcity[testSuiteStarted name='TestConstSub']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestConstSub' captureStandardOutput='true']
 ==================
 Write at 0x00c42007bdf0 by goroutine 9:
@@ -40,6 +41,7 @@ Goroutine 8 (finished) created at:
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestConstSub' duration='0']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestConstSub/subtest' captureStandardOutput='true']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestConstSub/subtest' duration='0']
+##teamcity[testSuiteFinished name='TestConstSub']
 PASS
 Found 1 data race(s)
 exit status 66

--- a/testdata/output/sample2
+++ b/testdata/output/sample2
@@ -8,11 +8,13 @@ PUT
 TEST
 ##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestConstError' details='const_test.go:56: nope']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestConstError' duration='30']
+##teamcity[testSuiteStarted name='TestConstSub']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestConstSub' captureStandardOutput='true']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestConstSub' duration='450']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestConstSub/subtest' captureStandardOutput='true']
 SUBTEST
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestConstSub/subtest' duration='0']
+##teamcity[testSuiteFinished name='TestConstSub']
 FAIL
 exit status 1
 FAIL	github.com/cockroachdb/apd	0.009s

--- a/testdata/output/sample3
+++ b/testdata/output/sample3
@@ -2,9 +2,11 @@
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestConstWithPrecision' duration='0']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestConstBlah' captureStandardOutput='true']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestConstBlah' duration='0']
+##teamcity[testSuiteStarted name='TestConstSub']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestConstSub' captureStandardOutput='true']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestConstSub' duration='0']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestConstSub/subtest' captureStandardOutput='true']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestConstSub/subtest' duration='0']
+##teamcity[testSuiteFinished name='TestConstSub']
 PASS
 ok  	github.com/cockroachdb/apd	0.009s

--- a/testdata/output/subtest
+++ b/testdata/output/subtest
@@ -1,6 +1,8 @@
+##teamcity[testSuiteStarted name='TestGDA']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestGDA' captureStandardOutput='true']
 ##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestGDA' details='']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestGDA' duration='130']
+##teamcity[testSuiteStarted name='TestGDA/add']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestGDA/add' captureStandardOutput='true']
 ##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestGDA/add' details='']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestGDA/add' duration='130']
@@ -17,9 +19,15 @@
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestGDA/add/addx1004' duration='0']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestGDA/add/addx1005' captureStandardOutput='true']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestGDA/add/addx1005' duration='0']
+##teamcity[testSuiteStarted name='TestGDA/add/addx1006']
 ##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestGDA/add/addx1006' captureStandardOutput='true']
 ##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestGDA/add/addx1006' details='gda_test.go:416: testdata/add.decTest:/^addx1006 |ngda_test.go:417: add 0 1.52446e-80 = 1.524E-81 (inexact rounded subnormal underflow)|ngda_test.go:418: prec: 5, round: half_up, Emax: 79, Emin: -79|ngda_test.go:540: want flags (120): underflow, inexact, subnormal, rounded|ngda_test.go:541: have flags (120): underflow, inexact, subnormal, rounded|ngda_test.go:619: want: 1.524E-81|ngda_test.go:620: got: 1.524E-80 ({Coeff: 1524, Exponent: -83})|ngda_test.go:639: unexpected result|ngda_test.go:464: duration: 113.143µs']
 ##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestGDA/add/addx1006' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestGDA/add/addx1006/subtest/name/with/slashes/in/it' captureStandardOutput='true']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestGDA/add/addx1006/subtest/name/with/slashes/in/it' duration='10']
+##teamcity[testSuiteFinished name='TestGDA/add/addx1006']
+##teamcity[testSuiteFinished name='TestGDA/add']
+##teamcity[testSuiteFinished name='TestGDA']
 FAIL
 exit status 1
 FAIL	github.com/cockroachdb/apd	0.138s


### PR DESCRIPTION
This will allow TeamCity's build log to load subtests on demand, as
their parent tests are expanded, which should vastly improve its
performance.

Check out how almost-usable this build log is: https://teamcity.cockroachdb.com/viewLog.html?buildId=511518&tab=buildLog&buildTypeId=Cockroach_UnitTests_Test&logTab=tree&filter=all#_state=308,1019