### PR TITLE
Rewrite to take test2json input

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -3,52 +3,72 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 )
 
 var (
-	inDir  = "testdata/input/"
-	outDir = "testdata/output/"
+	inDir  = "testdata/input"
+	outDir = "testdata/output"
 
 	timestampRegexp      = regexp.MustCompile(`timestamp='.*?'`)
 	timestampReplacement = `timestamp='2017-01-02T04:05:06.789'`
 )
 
 func TestProcessReader(t *testing.T) {
-	files, err := ioutil.ReadDir(inDir)
-	if err != nil {
-		t.Error(err)
-	}
-	for _, file := range files {
-		t.Run(file.Name(), func(t *testing.T) {
-			inpath := inDir + file.Name()
-			f, err := os.Open(inpath)
+	for _, json := range []bool{false, true} {
+		t.Run(fmt.Sprintf("json=%t", json), func(t *testing.T) {
+			sep := ""
+			if json {
+				sep = ".json"
+			}
+
+			files, err := ioutil.ReadDir(inDir + sep)
 			if err != nil {
 				t.Error(err)
 			}
-			in := bufio.NewReader(f)
+			for _, file := range files {
+				t.Run(file.Name(), func(t *testing.T) {
+					inpath := filepath.Join(inDir+sep, file.Name())
+					f, err := os.Open(inpath)
+					if err != nil {
+						t.Error(err)
+					}
+					in := bufio.NewReader(f)
 
-			out := &bytes.Buffer{}
-			processReader(in, out)
-			actual := out.String()
-			actual = timestampRegexp.ReplaceAllString(actual, timestampReplacement)
+					out := &bytes.Buffer{}
+					if json {
+						processJSON(in, out)
+					} else {
+						processReader(in, out)
+					}
+					actual := out.String()
+					actual = timestampRegexp.ReplaceAllString(actual, timestampReplacement)
 
-			outpath := outDir + file.Name()
-			t.Logf("input: %s", inpath)
-			t.Logf("output: %s", outpath)
-			expectedBytes, err := ioutil.ReadFile(outpath)
-			if err != nil {
-				t.Error(err)
-			}
-			expected := string(expectedBytes)
-			expected = timestampRegexp.ReplaceAllString(expected, timestampReplacement)
+					outpath := filepath.Join(outDir+sep, file.Name())
+					t.Logf("input: %s", inpath)
+					t.Logf("output: %s", outpath)
+					expectedBytes, err := ioutil.ReadFile(outpath)
+					if err != nil {
+						t.Error(err)
+					}
+					expected := string(expectedBytes)
+					expected = timestampRegexp.ReplaceAllString(expected, timestampReplacement)
 
-			if strings.Compare(expected, actual) != 0 {
-				t.Errorf("expected:\n\n%s\nbut got:\n\n%s\n", expected, actual)
+					const rewriteOutput = true
+					if rewriteOutput {
+						_ = ioutil.WriteFile(outpath, []byte(actual), 0644)
+					}
+
+					if strings.Compare(expected, actual) != 0 {
+						t.Errorf("expected:\n\n%s\nbut got:\n\n%s\n", expected, actual)
+					}
+				})
 			}
 		})
 	}

--- a/testdata/input.json/test.json.txt
+++ b/testdata/input.json/test.json.txt
@@ -1,0 +1,440 @@
+build/builder.sh env TZ=America/New_York COCKROACH_FAILSUITE=true make test PKG=./pkg/util/failsuite/... TESTFLAGS=-v -json
+GOPATH set to /go
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/utilities
+github.com/cockroachdb/cockroach/vendor/github.com/armon/go-radix
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/paths
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/ttycolor
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/internal/fastwalk
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/ast/astutil
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/go/printer
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/stress
+github.com/cockroachdb/cockroach/vendor/github.com/client9/misspell
+github.com/cockroachdb/cockroach/vendor/github.com/Masterminds/semver
+github.com/cockroachdb/cockroach/vendor/github.com/Masterminds/vcs
+github.com/cockroachdb/cockroach/vendor/github.com/boltdb/bolt
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/proto
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/imports
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/cmd/gofmt
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/go/format
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/pkgtree
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/imports
+github.com/cockroachdb/cockroach/vendor/github.com/pkg/errors
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/fs
+github.com/cockroachdb/cockroach/vendor/github.com/jmank88/nuts
+github.com/cockroachdb/cockroach/vendor/github.com/nightlyone/lockfile
+github.com/cockroachdb/cockroach/vendor/github.com/sdboyer/constext
+github.com/cockroachdb/cockroach/vendor/golang.org/x/net/context
+github.com/cockroachdb/cockroach/vendor/github.com/pelletier/go-toml
+github.com/cockroachdb/cockroach/vendor/golang.org/x/sync/errgroup
+github.com/cockroachdb/cockroach/vendor/gopkg.in/yaml.v2
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/gcimporter15
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/crlfmt
+github.com/cockroachdb/cockroach/vendor/github.com/client9/misspell/cmd/misspell
+github.com/cockroachdb/cockroach/vendor/github.com/golang/glog
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/cmd/goimports
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/internal/pb
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/gcexportdata
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor
+github.com/cockroachdb/cockroach/vendor/github.com/golang/lint
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/generator/internal/remap
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/httprule
+github.com/cockroachdb/cockroach/vendor/github.com/jteeuwen/go-bindata
+github.com/cockroachdb/cockroach/vendor/github.com/golang/lint/golint
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/buildutil
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/plugin
+github.com/cockroachdb/cockroach/vendor/google.golang.org/genproto/googleapis/api/annotations
+github.com/cockroachdb/cockroach/vendor/github.com/jteeuwen/go-bindata/go-bindata
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/generator
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/loader
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/gotool/internal/load
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cover
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/gotool
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/suffixtree
+github.com/cockroachdb/cockroach/vendor/github.com/mattn/goveralls
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/errcheck/internal/errcheck
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/syntax
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/syntax/golang
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/output
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/errcheck
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/job
+github.com/cockroachdb/cockroach/vendor/github.com/wadey/gocovmerge
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/internal/stats
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/storage/benchfmt
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cmd/goyacc
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/benchstat
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/verify
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/feedback
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/cmd/benchstat
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cmd/stringer
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/generator
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/gengateway
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/base
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/glide
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/glock
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/govendor
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/govend
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/godep
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/gvt
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/vndr
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/cmd/dep
+touch bin/.bootstrap
+go install -v protoc-gen-gogoroach
+bin/prereqs ./pkg/cmd/protoc-gen-gogoroach > bin/protoc-gen-gogoroach.d.tmp
+mv -f bin/protoc-gen-gogoroach.d.tmp bin/protoc-gen-gogoroach.d
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/proto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/descriptor
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/plugin
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/gogoproto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/vanity
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/generator
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/defaultcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/testgen
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/unmarshal
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/marshalto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/embedcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/enumstringer
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/oneofcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/populate
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/grpc
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/description
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/compare
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/face
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/gostring
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/equal
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/size
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/stringer
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/union
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/vanity/command
+github.com/cockroachdb/cockroach/pkg/cmd/protoc-gen-gogoroach
+find ./pkg -name node_modules -prune -o -type f -name '*.pb.go' -exec rm {} +
+set -e; for dir in ./pkg/acceptance/cluster/ ./pkg/build/ ./pkg/ccl/backupccl/ ./pkg/ccl/baseccl/ ./pkg/ccl/storageccl/engineccl/enginepbccl/ ./pkg/ccl/utilccl/licenseccl/ ./pkg/config/ ./pkg/gossip/ ./pkg/internal/client/ ./pkg/jobs/jobspb/ ./pkg/roachpb/ ./pkg/rpc/ ./pkg/server/diagnosticspb/ ./pkg/server/serverpb/ ./pkg/server/status/ ./pkg/settings/cluster/ ./pkg/sql/distsqlrun/ ./pkg/sql/pgwire/pgerror/ ./pkg/sql/sqlbase/ ./pkg/sql/stats/ ./pkg/storage/ ./pkg/storage/closedts/ctpb/ ./pkg/storage/engine/enginepb/ ./pkg/storage/storagebase/ ./pkg/ts/tspb/ ./pkg/util/ ./pkg/util/hlc/ ./pkg/util/log/ ./pkg/util/metric/ ./pkg/util/protoutil/ ./pkg/util/tracing/; do \
+  build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --gogoroach_out=Mgoogle/api/annotations.proto=github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,,plugins=grpc,import_prefix=github.com/cockroachdb/cockroach/pkg/:./pkg $dir/*.proto; \
+done
+sed -i '/import _/d' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!import (fmt|math) "github.com/cockroachdb/cockroach/pkg/(fmt|math)"! !g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!github\.com/cockroachdb/cockroach/pkg/(etcd)!go.etcd.io/\1!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!cockroachdb/cockroach/pkg/(prometheus/client_model)!\1/go!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!github.com/cockroachdb/cockroach/pkg/(bytes|encoding/binary|errors|fmt|io|math|github\.com|(google\.)?golang\.org)!\1!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!golang.org/x/net/context!context!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+gofmt -s -w ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+touch bin/.go_protobuf_sources
+find ./pkg -name node_modules -prune -o -type f -name '*.pb.gw.go' -exec rm {} +
+build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true,request_context=true:./pkg ./pkg/server/serverpb/admin.proto ./pkg/server/serverpb/status.proto ./pkg/server/serverpb/authentication.proto
+build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true,request_context=true:./pkg ./pkg/ts/tspb/timeseries.proto
+sed -i -E 's!golang.org/x/net/context!context!g' ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+gofmt -s -w ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+goimports -w ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+touch bin/.gw_protobuf_sources
+mkdir -p pkg/sql/parser/gen
+set -euo pipefail; \
+TYPES=$(awk '/func.*sqlSymUnion/ {print $(NF - 1)}' pkg/sql/parser/sql.y | sed -e 's/[]\/$*.^|[]/\\&/g' | tr '\n' '|' | sed -E '$s/.$//'); \
+sed -E "s_(type|token) <($TYPES)>_\1 <union> /* <\2> */_" < pkg/sql/parser/sql.y | \
+awk -f pkg/sql/parser/replace_help_rules.awk | \
+sed -Ee 's,//.*$,,g;s,/[*]([^*]|[*][^/])*[*]/, ,g;s/ +$//g' > pkg/sql/parser/gen/sql-gen.y.tmp || rm pkg/sql/parser/gen/sql-gen.y.tmp
+mv -f pkg/sql/parser/gen/sql-gen.y.tmp pkg/sql/parser/gen/sql-gen.y
+set -euo pipefail; \
+  ret=$(cd pkg/sql/parser/gen && goyacc -p sql -o sql.go.tmp sql-gen.y); \
+  if expr "$ret" : ".*conflicts" >/dev/null; then \
+    echo "$ret"; exit 1; \
+  fi
+(echo "// Code generated by goyacc. DO NOT EDIT."; \
+ echo "// GENERATED FILE DO NOT EDIT"; \
+ cat pkg/sql/parser/gen/sql.go.tmp | \
+ sed -E 's/^const ([A-Z][_A-Z0-9]*) =.*$/const \1 = lex.\1/g') > pkg/sql/parser/sql.go.tmp || rm pkg/sql/parser/sql.go.tmp
+mv -f pkg/sql/parser/sql.go.tmp pkg/sql/parser/sql.go
+goimports -w pkg/sql/parser/sql.go
+mv -f pkg/sql/parser/helpmap_test.go.tmp pkg/sql/parser/helpmap_test.go
+gofmt -s -w pkg/sql/parser/helpmap_test.go
+awk -f pkg/sql/parser/help.awk < pkg/sql/parser/sql.y > pkg/sql/parser/help_messages.go.tmp || rm pkg/sql/parser/help_messages.go.tmp
+mv -f pkg/sql/parser/help_messages.go.tmp pkg/sql/parser/help_messages.go
+gofmt -s -w pkg/sql/parser/help_messages.go
+(echo "// Code generated by make. DO NOT EDIT."; \
+ echo "// GENERATED FILE DO NOT EDIT"; \
+ echo; \
+ echo "package lex"; \
+ echo; \
+ grep '^const [A-Z][_A-Z0-9]* ' pkg/sql/parser/gen/sql.go.tmp) > pkg/sql/lex/tokens.go.tmp || rm pkg/sql/lex/tokens.go.tmp
+mv -f pkg/sql/lex/tokens.go.tmp pkg/sql/lex/tokens.go
+awk -f pkg/sql/parser/all_keywords.awk < pkg/sql/parser/sql.y > pkg/sql/lex/keywords.go.tmp || rm pkg/sql/lex/keywords.go.tmp
+mv -f pkg/sql/lex/keywords.go.tmp pkg/sql/lex/keywords.go
+gofmt -s -w pkg/sql/lex/keywords.go
+awk -f pkg/sql/parser/reserved_keywords.awk < pkg/sql/parser/sql.y > pkg/sql/lex/reserved_keywords.go.tmp || rm pkg/sql/lex/reserved_keywords.go.tmp
+mv -f pkg/sql/lex/reserved_keywords.go.tmp pkg/sql/lex/reserved_keywords.go
+gofmt -s -w pkg/sql/lex/reserved_keywords.go
+go install -v optgen
+bin/prereqs ./pkg/sql/opt/optgen/cmd/optgen > bin/optgen.d.tmp
+mv -f bin/optgen.d.tmp bin/optgen.d
+github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang
+github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/cmd/optgen
+optgen -out pkg/sql/opt/memo/expr.og.go exprs pkg/sql/opt/ops/*.opt
+optgen -out pkg/sql/opt/operator.og.go ops pkg/sql/opt/ops/*.opt
+optgen -out pkg/sql/opt/xform/explorer.og.go explorer pkg/sql/opt/ops/*.opt pkg/sql/opt/xform/rules/*.opt
+optgen -out pkg/sql/opt/norm/factory.og.go factory pkg/sql/opt/ops/*.opt pkg/sql/opt/norm/rules/*.opt
+optgen -out pkg/sql/opt/rule_name.og.go rulenames pkg/sql/opt/ops/*.opt pkg/sql/opt/norm/rules/*.opt pkg/sql/opt/xform/rules/*.opt
+stringer -output=pkg/sql/opt/rule_name_string.go -type=RuleName pkg/sql/opt/rule_name.go pkg/sql/opt/rule_name.og.go
+go test  -tags ' make x86_64_pc_linux_gnu' -ldflags '-X github.com/cockroachdb/cockroach/pkg/build.typ=development -extldflags "" -X "github.com/cockroachdb/cockroach/pkg/build.tag=v2.2.0-alpha.00000000-925-g3baa3d9" -X "github.com/cockroachdb/cockroach/pkg/build.rev=3baa3d9b299a392b7d9b737dbfb333d095e672a9" -X "github.com/cockroachdb/cockroach/pkg/build.cgoTargetTriple=x86_64-pc-linux-gnu"  ' -run "."  -timeout 8m ./pkg/util/failsuite/... -v -json
+{"Time":"2018-09-19T10:17:19.719825861-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics"}
+{"Time":"2018-09-19T10:17:19.720125532-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"=== RUN   TestZPanics\n"}
+{"Time":"2018-09-19T10:17:19.720136726-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"first output something\n"}
+{"Time":"2018-09-19T10:17:19.720148958-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"--- FAIL: TestZPanics (0.00s)\n"}
+{"Time":"2018-09-19T10:17:19.720155052-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\tmain_test.go:35: then log something\n"}
+{"Time":"2018-09-19T10:17:19.720159489-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\tmain_test.go:36: an error, why not\n"}
+{"Time":"2018-09-19T10:17:19.722075923-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"panic: boom [recovered]\n"}
+{"Time":"2018-09-19T10:17:19.722124762-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\tpanic: boom\n"}
+{"Time":"2018-09-19T10:17:19.722137639-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\n"}
+{"Time":"2018-09-19T10:17:19.722142072-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"goroutine 6 [running]:\n"}
+{"Time":"2018-09-19T10:17:19.722146225-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.tRunner.func1(0xc4200d41e0)\n"}
+{"Time":"2018-09-19T10:17:19.722150585-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:742 +0x29d\n"}
+{"Time":"2018-09-19T10:17:19.722189154-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"panic(0x51c5e0, 0x56c2b0)\n"}
+{"Time":"2018-09-19T10:17:19.722193861-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/runtime/panic.go:502 +0x229\n"}
+{"Time":"2018-09-19T10:17:19.722209085-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic.TestZPanics(0xc4200d41e0)\n"}
+{"Time":"2018-09-19T10:17:19.722214171-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic/main_test.go:37 +0x113\n"}
+{"Time":"2018-09-19T10:17:19.72221859-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.tRunner(0xc4200d41e0, 0x55c110)\n"}
+{"Time":"2018-09-19T10:17:19.722224678-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:777 +0xd0\n"}
+{"Time":"2018-09-19T10:17:19.722234366-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"created by testing.(*T).Run\n"}
+{"Time":"2018-09-19T10:17:19.722238669-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:824 +0x2e0\n"}
+{"Time":"2018-09-19T10:17:19.722246214-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\n"}
+{"Time":"2018-09-19T10:17:19.722250788-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"goroutine 1 [chan receive]:\n"}
+{"Time":"2018-09-19T10:17:19.7222552-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.(*T).Run(0xc4200d41e0, 0x554258, 0xb, 0x55c110, 0x473276)\n"}
+{"Time":"2018-09-19T10:17:19.722259375-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:825 +0x301\n"}
+{"Time":"2018-09-19T10:17:19.722263306-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.runTests.func1(0xc4200d40f0)\n"}
+{"Time":"2018-09-19T10:17:19.722267169-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:1063 +0x64\n"}
+{"Time":"2018-09-19T10:17:19.722270972-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.tRunner(0xc4200d40f0, 0xc420067dc8)\n"}
+{"Time":"2018-09-19T10:17:19.72227453-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:777 +0xd0\n"}
+{"Time":"2018-09-19T10:17:19.722278086-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.runTests(0xc42000c380, 0x609720, 0x1, 0x1, 0x0)\n"}
+{"Time":"2018-09-19T10:17:19.722281428-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:1061 +0x2c4\n"}
+{"Time":"2018-09-19T10:17:19.722285092-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.(*M).Run(0xc4200d6000, 0x0)\n"}
+{"Time":"2018-09-19T10:17:19.722395969-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:978 +0x171\n"}
+{"Time":"2018-09-19T10:17:19.722418112-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic.TestMain(0xc4200d6000)\n"}
+{"Time":"2018-09-19T10:17:19.722427097-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic/main_test.go:30 +0x52\n"}
+{"Time":"2018-09-19T10:17:19.722437765-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"main.main()\n"}
+{"Time":"2018-09-19T10:17:19.722445505-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t_testmain.go:40 +0x151\n"}
+{"Time":"2018-09-19T10:17:19.722717309-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"FAIL\tgithub.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic\t0.006s\n"}
+{"Time":"2018-09-19T10:17:19.722756653-04:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Elapsed":0.006}
+{"Time":"2018-09-19T10:17:19.730174467-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatPasses"}
+{"Time":"2018-09-19T10:17:19.730227338-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatPasses","Output":"=== RUN   TestThatPasses\n"}
+{"Time":"2018-09-19T10:17:19.730246047-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatPasses","Output":"output of TestThatPasses\n"}
+{"Time":"2018-09-19T10:17:19.730266512-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatPasses","Output":"--- PASS: TestThatPasses (0.00s)\n"}
+{"Time":"2018-09-19T10:17:19.730273548-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatPasses","Elapsed":0}
+{"Time":"2018-09-19T10:17:19.730284294-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails"}
+{"Time":"2018-09-19T10:17:19.73029-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails","Output":"=== RUN   TestThatFails\n"}
+{"Time":"2018-09-19T10:17:19.730298327-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails","Output":"--- FAIL: TestThatFails (0.00s)\n"}
+{"Time":"2018-09-19T10:17:19.730306618-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails","Output":"\tmain_test.go:41: an error occurs\n"}
+{"Time":"2018-09-19T10:17:19.730312086-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails","Output":"\tmain_test.go:42: then the test fatals\n"}
+{"Time":"2018-09-19T10:17:19.730317886-04:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails","Elapsed":0}
+{"Time":"2018-09-19T10:17:19.730328343-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped"}
+{"Time":"2018-09-19T10:17:19.7303371-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped","Output":"=== RUN   TestThatGetsSkipped\n"}
+{"Time":"2018-09-19T10:17:19.730345351-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped","Output":"--- SKIP: TestThatGetsSkipped (0.00s)\n"}
+{"Time":"2018-09-19T10:17:19.730351515-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped","Output":"\tmain_test.go:46: logging something\n"}
+{"Time":"2018-09-19T10:17:19.730356905-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped","Output":"\tmain_test.go:47: skipped\n"}
+{"Time":"2018-09-19T10:17:19.730362856-04:00","Action":"skip","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped","Elapsed":0}
+{"Time":"2018-09-19T10:17:19.730368958-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures"}
+{"Time":"2018-09-19T10:17:19.730375921-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures\n"}
+{"Time":"2018-09-19T10:17:19.730383737-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures","Output":"output before calling t.Parallel()\n"}
+{"Time":"2018-09-19T10:17:19.730390549-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures\n"}
+{"Time":"2018-09-19T10:17:19.730399035-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures"}
+{"Time":"2018-09-19T10:17:19.730404325-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures"}
+{"Time":"2018-09-19T10:17:19.73040958-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures","Output":"=== RUN   TestParallelWithDataRaceAndFailures\n"}
+{"Time":"2018-09-19T10:17:19.730414658-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures","Output":"output before calling t.Parallel()\n"}
+{"Time":"2018-09-19T10:17:19.730420897-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures","Output":"=== PAUSE TestParallelWithDataRaceAndFailures\n"}
+{"Time":"2018-09-19T10:17:19.730425812-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures"}
+{"Time":"2018-09-19T10:17:19.730431504-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures"}
+{"Time":"2018-09-19T10:17:19.730437168-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures\n"}
+{"Time":"2018-09-19T10:17:19.730443737-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0"}
+{"Time":"2018-09-19T10:17:19.730449486-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/0\n"}
+{"Time":"2018-09-19T10:17:19.730487095-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/0\n"}
+{"Time":"2018-09-19T10:17:19.730494306-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0"}
+{"Time":"2018-09-19T10:17:19.730501008-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1"}
+{"Time":"2018-09-19T10:17:19.73050691-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/1\n"}
+{"Time":"2018-09-19T10:17:19.730513804-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/1\n"}
+{"Time":"2018-09-19T10:17:19.730519865-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1"}
+{"Time":"2018-09-19T10:17:19.730524662-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2"}
+{"Time":"2018-09-19T10:17:19.730533331-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/2\n"}
+{"Time":"2018-09-19T10:17:19.730540443-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/2\n"}
+{"Time":"2018-09-19T10:17:19.730546589-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2"}
+{"Time":"2018-09-19T10:17:19.7305537-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3"}
+{"Time":"2018-09-19T10:17:19.730559739-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/3\n"}
+{"Time":"2018-09-19T10:17:19.730566384-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/3\n"}
+{"Time":"2018-09-19T10:17:19.730571526-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3"}
+{"Time":"2018-09-19T10:17:19.730602718-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4"}
+{"Time":"2018-09-19T10:17:19.730608405-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/4\n"}
+{"Time":"2018-09-19T10:17:19.730614358-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/4\n"}
+{"Time":"2018-09-19T10:17:19.730623336-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4"}
+{"Time":"2018-09-19T10:17:19.730629392-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5"}
+{"Time":"2018-09-19T10:17:19.73063466-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/5\n"}
+{"Time":"2018-09-19T10:17:19.730641068-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/5\n"}
+{"Time":"2018-09-19T10:17:19.730646254-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5"}
+{"Time":"2018-09-19T10:17:19.730652121-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6"}
+{"Time":"2018-09-19T10:17:19.730658424-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/6\n"}
+{"Time":"2018-09-19T10:17:19.730665178-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/6\n"}
+{"Time":"2018-09-19T10:17:19.73067028-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6"}
+{"Time":"2018-09-19T10:17:19.730679265-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7"}
+{"Time":"2018-09-19T10:17:19.730687919-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/7\n"}
+{"Time":"2018-09-19T10:17:19.730694325-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/7\n"}
+{"Time":"2018-09-19T10:17:19.730700066-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7"}
+{"Time":"2018-09-19T10:17:19.730705795-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8"}
+{"Time":"2018-09-19T10:17:19.730711039-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/8\n"}
+{"Time":"2018-09-19T10:17:19.73071754-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/8\n"}
+{"Time":"2018-09-19T10:17:19.730723627-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8"}
+{"Time":"2018-09-19T10:17:19.730729334-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9"}
+{"Time":"2018-09-19T10:17:19.73073567-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/9\n"}
+{"Time":"2018-09-19T10:17:19.73075842-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/9\n"}
+{"Time":"2018-09-19T10:17:19.730765838-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9"}
+{"Time":"2018-09-19T10:17:19.730781331-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0"}
+{"Time":"2018-09-19T10:17:19.730791953-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/0\n"}
+{"Time":"2018-09-19T10:17:19.730805563-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9"}
+{"Time":"2018-09-19T10:17:19.73081748-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/9\n"}
+{"Time":"2018-09-19T10:17:19.730830318-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8"}
+{"Time":"2018-09-19T10:17:19.730842215-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/8\n"}
+{"Time":"2018-09-19T10:17:19.730854835-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7"}
+{"Time":"2018-09-19T10:17:19.730861219-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/7\n"}
+{"Time":"2018-09-19T10:17:19.730869685-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6"}
+{"Time":"2018-09-19T10:17:19.730874325-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/6\n"}
+{"Time":"2018-09-19T10:17:19.730879233-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5"}
+{"Time":"2018-09-19T10:17:19.73088392-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/5\n"}
+{"Time":"2018-09-19T10:17:19.730895079-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4"}
+{"Time":"2018-09-19T10:17:19.730906378-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/4\n"}
+{"Time":"2018-09-19T10:17:19.730918725-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3"}
+{"Time":"2018-09-19T10:17:19.730930407-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/3\n"}
+{"Time":"2018-09-19T10:17:19.871844231-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2"}
+{"Time":"2018-09-19T10:17:19.87190445-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/2\n"}
+{"Time":"2018-09-19T10:17:19.939063346-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1"}
+{"Time":"2018-09-19T10:17:19.939125607-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/1\n"}
+{"Time":"2018-09-19T10:17:20.029251375-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures"}
+{"Time":"2018-09-19T10:17:20.029308037-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures","Output":"=== CONT  TestParallelWithDataRaceAndFailures\n"}
+{"Time":"2018-09-19T10:17:20.029442449-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0"}
+{"Time":"2018-09-19T10:17:20.029457874-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0","Output":"=== RUN   TestParallelWithDataRaceAndFailures/0\n"}
+{"Time":"2018-09-19T10:17:20.029489641-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/0\n"}
+{"Time":"2018-09-19T10:17:20.029518413-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0"}
+{"Time":"2018-09-19T10:17:20.029525793-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1"}
+{"Time":"2018-09-19T10:17:20.02953223-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1","Output":"=== RUN   TestParallelWithDataRaceAndFailures/1\n"}
+{"Time":"2018-09-19T10:17:20.029540455-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/1\n"}
+{"Time":"2018-09-19T10:17:20.0295463-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1"}
+{"Time":"2018-09-19T10:17:20.029569029-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2"}
+{"Time":"2018-09-19T10:17:20.029576231-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2","Output":"=== RUN   TestParallelWithDataRaceAndFailures/2\n"}
+{"Time":"2018-09-19T10:17:20.029583131-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/2\n"}
+{"Time":"2018-09-19T10:17:20.02958847-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2"}
+{"Time":"2018-09-19T10:17:20.029595656-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3"}
+{"Time":"2018-09-19T10:17:20.029601637-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3","Output":"=== RUN   TestParallelWithDataRaceAndFailures/3\n"}
+{"Time":"2018-09-19T10:17:20.029699955-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/3\n"}
+{"Time":"2018-09-19T10:17:20.029712403-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3"}
+{"Time":"2018-09-19T10:17:20.029719402-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4"}
+{"Time":"2018-09-19T10:17:20.029734259-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4","Output":"=== RUN   TestParallelWithDataRaceAndFailures/4\n"}
+{"Time":"2018-09-19T10:17:20.029745732-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/4\n"}
+{"Time":"2018-09-19T10:17:20.029751691-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4"}
+{"Time":"2018-09-19T10:17:20.029757478-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5"}
+{"Time":"2018-09-19T10:17:20.029764566-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5","Output":"=== RUN   TestParallelWithDataRaceAndFailures/5\n"}
+{"Time":"2018-09-19T10:17:20.029797563-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/5\n"}
+{"Time":"2018-09-19T10:17:20.029819136-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5"}
+{"Time":"2018-09-19T10:17:20.029827045-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6"}
+{"Time":"2018-09-19T10:17:20.029849351-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6","Output":"=== RUN   TestParallelWithDataRaceAndFailures/6\n"}
+{"Time":"2018-09-19T10:17:20.029858615-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/6\n"}
+{"Time":"2018-09-19T10:17:20.02987173-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6"}
+{"Time":"2018-09-19T10:17:20.029882382-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7"}
+{"Time":"2018-09-19T10:17:20.029887633-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7","Output":"=== RUN   TestParallelWithDataRaceAndFailures/7\n"}
+{"Time":"2018-09-19T10:17:20.029905877-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/7\n"}
+{"Time":"2018-09-19T10:17:20.029913836-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7"}
+{"Time":"2018-09-19T10:17:20.029943668-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/8"}
+{"Time":"2018-09-19T10:17:20.029970545-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/8","Output":"=== RUN   TestParallelWithDataRaceAndFailures/8\n"}
+{"Time":"2018-09-19T10:17:20.029984905-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/8","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/8\n"}
+{"Time":"2018-09-19T10:17:20.029996212-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/8"}
+{"Time":"2018-09-19T10:17:20.030002539-04:00","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/9"}
+{"Time":"2018-09-19T10:17:20.030012235-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/9","Output":"=== RUN   TestParallelWithDataRaceAndFailures/9\n"}
+{"Time":"2018-09-19T10:17:20.030019028-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/9","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/9\n"}
+{"Time":"2018-09-19T10:17:20.030024861-04:00","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/9"}
+{"Time":"2018-09-19T10:17:20.030042241-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0"}
+{"Time":"2018-09-19T10:17:20.0300684-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0","Output":"=== CONT  TestParallelWithDataRaceAndFailures/0\n"}
+{"Time":"2018-09-19T10:17:20.045839672-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/9"}
+{"Time":"2018-09-19T10:17:20.045897955-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/9","Output":"=== CONT  TestParallelWithDataRaceAndFailures/9\n"}
+{"Time":"2018-09-19T10:17:20.066969612-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/8"}
+{"Time":"2018-09-19T10:17:20.067029249-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/8","Output":"=== CONT  TestParallelWithDataRaceAndFailures/8\n"}
+{"Time":"2018-09-19T10:17:20.15794488-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7"}
+{"Time":"2018-09-19T10:17:20.158018274-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7","Output":"=== CONT  TestParallelWithDataRaceAndFailures/7\n"}
+{"Time":"2018-09-19T10:17:20.205892405-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6"}
+{"Time":"2018-09-19T10:17:20.205952033-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6","Output":"=== CONT  TestParallelWithDataRaceAndFailures/6\n"}
+{"Time":"2018-09-19T10:17:20.213004494-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5"}
+{"Time":"2018-09-19T10:17:20.213065869-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5","Output":"=== CONT  TestParallelWithDataRaceAndFailures/5\n"}
+{"Time":"2018-09-19T10:17:20.506345985-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4"}
+{"Time":"2018-09-19T10:17:20.506404944-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4","Output":"=== CONT  TestParallelWithDataRaceAndFailures/4\n"}
+{"Time":"2018-09-19T10:17:20.518655242-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3"}
+{"Time":"2018-09-19T10:17:20.518715211-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3","Output":"=== CONT  TestParallelWithDataRaceAndFailures/3\n"}
+{"Time":"2018-09-19T10:17:20.642823644-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2"}
+{"Time":"2018-09-19T10:17:20.642887399-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2","Output":"=== CONT  TestParallelWithDataRaceAndFailures/2\n"}
+{"Time":"2018-09-19T10:17:20.670752203-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures","Output":"--- PASS: TestParallelOneWithDataRaceWithoutFailures (0.00s)\n"}
+{"Time":"2018-09-19T10:17:20.670861333-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5","Output":"    --- PASS: TestParallelOneWithDataRaceWithoutFailures/5 (0.14s)\n"}
+{"Time":"2018-09-19T10:17:20.670878673-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:20.670884881-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5","Elapsed":0.14}
+{"Time":"2018-09-19T10:17:20.670895947-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3","Output":"    --- PASS: TestParallelOneWithDataRaceWithoutFailures/3 (0.21s)\n"}
+{"Time":"2018-09-19T10:17:20.670900972-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:20.670906431-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3","Elapsed":0.21}
+{"Time":"2018-09-19T10:17:20.670911667-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0","Output":"    --- PASS: TestParallelOneWithDataRaceWithoutFailures/0 (0.30s)\n"}
+{"Time":"2018-09-19T10:17:20.67091859-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:20.670923761-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0","Elapsed":0.3}
+{"Time":"2018-09-19T10:17:20.670928316-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1","Output":"    --- PASS: TestParallelOneWithDataRaceWithoutFailures/1 (0.11s)\n"}
+{"Time":"2018-09-19T10:17:20.670932529-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:20.670936513-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1","Elapsed":0.11}
+{"Time":"2018-09-19T10:17:20.670943215-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4","Output":"    --- PASS: TestParallelOneWithDataRaceWithoutFailures/4 (0.34s)\n"}
+{"Time":"2018-09-19T10:17:20.670947429-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:20.670951964-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4","Elapsed":0.34}
+{"Time":"2018-09-19T10:17:20.670955451-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9","Output":"    --- PASS: TestParallelOneWithDataRaceWithoutFailures/9 (0.43s)\n"}
+{"Time":"2018-09-19T10:17:20.670959403-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:20.670963448-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9","Elapsed":0.43}
+{"Time":"2018-09-19T10:17:20.67096667-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6","Output":"    --- PASS: TestParallelOneWithDataRaceWithoutFailures/6 (0.48s)\n"}
+{"Time":"2018-09-19T10:17:20.670970637-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:20.670976366-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6","Elapsed":0.48}
+{"Time":"2018-09-19T10:17:20.670979823-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2","Output":"    --- PASS: TestParallelOneWithDataRaceWithoutFailures/2 (0.65s)\n"}
+{"Time":"2018-09-19T10:17:20.670984715-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:20.670996835-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2","Elapsed":0.65}
+{"Time":"2018-09-19T10:17:20.671024896-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7","Output":"    --- PASS: TestParallelOneWithDataRaceWithoutFailures/7 (0.91s)\n"}
+{"Time":"2018-09-19T10:17:20.671030254-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:20.671034622-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7","Elapsed":0.91}
+{"Time":"2018-09-19T10:17:20.671038328-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"    --- PASS: TestParallelOneWithDataRaceWithoutFailures/8 (0.94s)\n"}
+{"Time":"2018-09-19T10:17:20.671041863-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:20.671045702-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Elapsed":0.94}
+{"Time":"2018-09-19T10:17:20.671062998-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures","Elapsed":0}
+{"Time":"2018-09-19T10:17:20.671067832-04:00","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1"}
+{"Time":"2018-09-19T10:17:20.671071544-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1","Output":"=== CONT  TestParallelWithDataRaceAndFailures/1\n"}
+{"Time":"2018-09-19T10:17:21.136215557-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures","Output":"--- FAIL: TestParallelWithDataRaceAndFailures (0.00s)\n"}
+{"Time":"2018-09-19T10:17:21.136320696-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6","Output":"    --- FAIL: TestParallelWithDataRaceAndFailures/6 (0.01s)\n"}
+{"Time":"2018-09-19T10:17:21.136328037-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6","Output":"    \tmain_test.go:81: subtest failed\n"}
+{"Time":"2018-09-19T10:17:21.13633339-04:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6","Elapsed":0.01}
+{"Time":"2018-09-19T10:17:21.136346652-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/9","Output":"    --- FAIL: TestParallelWithDataRaceAndFailures/9 (0.46s)\n"}
+{"Time":"2018-09-19T10:17:21.136351638-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/9","Output":"    \tmain_test.go:81: subtest failed\n"}
+{"Time":"2018-09-19T10:17:21.136356752-04:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/9","Elapsed":0.46}
+{"Time":"2018-09-19T10:17:21.136361072-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0","Output":"    --- FAIL: TestParallelWithDataRaceAndFailures/0 (0.75s)\n"}
+{"Time":"2018-09-19T10:17:21.136368789-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0","Output":"    \tmain_test.go:81: subtest failed\n"}
+{"Time":"2018-09-19T10:17:21.136374432-04:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0","Elapsed":0.75}
+{"Time":"2018-09-19T10:17:21.136377998-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5","Output":"    --- PASS: TestParallelWithDataRaceAndFailures/5 (0.61s)\n"}
+{"Time":"2018-09-19T10:17:21.136381687-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:21.136385632-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5","Elapsed":0.61}
+{"Time":"2018-09-19T10:17:21.136389704-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7","Output":"    --- PASS: TestParallelWithDataRaceAndFailures/7 (0.68s)\n"}
+{"Time":"2018-09-19T10:17:21.136399103-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:21.136403393-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7","Elapsed":0.68}
+{"Time":"2018-09-19T10:17:21.136407356-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/8","Output":"    --- PASS: TestParallelWithDataRaceAndFailures/8 (0.82s)\n"}
+{"Time":"2018-09-19T10:17:21.136411455-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/8","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:21.136415274-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/8","Elapsed":0.82}
+{"Time":"2018-09-19T10:17:21.136418677-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3","Output":"    --- FAIL: TestParallelWithDataRaceAndFailures/3 (0.46s)\n"}
+{"Time":"2018-09-19T10:17:21.13642218-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3","Output":"    \tmain_test.go:81: subtest failed\n"}
+{"Time":"2018-09-19T10:17:21.136426047-04:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3","Elapsed":0.46}
+{"Time":"2018-09-19T10:17:21.136429298-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1","Output":"    --- PASS: TestParallelWithDataRaceAndFailures/1 (0.44s)\n"}
+{"Time":"2018-09-19T10:17:21.136432618-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:21.13643626-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1","Elapsed":0.44}
+{"Time":"2018-09-19T10:17:21.136442793-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2","Output":"    --- PASS: TestParallelWithDataRaceAndFailures/2 (0.47s)\n"}
+{"Time":"2018-09-19T10:17:21.136446983-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:21.136450815-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2","Elapsed":0.47}
+{"Time":"2018-09-19T10:17:21.136455878-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4","Output":"    --- PASS: TestParallelWithDataRaceAndFailures/4 (0.63s)\n"}
+{"Time":"2018-09-19T10:17:21.136460377-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4","Output":"    \tmain_test.go:83: something gets logged\n"}
+{"Time":"2018-09-19T10:17:21.136463869-04:00","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4","Elapsed":0.63}
+{"Time":"2018-09-19T10:17:21.136542778-04:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures","Elapsed":0}
+{"Time":"2018-09-19T10:17:21.136548534-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Output":"FAIL\n"}
+{"Time":"2018-09-19T10:17:21.136935249-04:00","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Output":"FAIL\tgithub.com/cockroachdb/cockroach/pkg/util/failsuite\t1.409s\n"}
+{"Time":"2018-09-19T10:17:21.136996403-04:00","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Elapsed":1.409}
+make: *** [test] Error 1
+Makefile:830: recipe for target 'test' failed
+

--- a/testdata/input.json/testrace.json.txt
+++ b/testdata/input.json/testrace.json.txt
@@ -1,0 +1,643 @@
+build/builder.sh env COCKROACH_FAILSUITE=1 COCKROACH_LOGIC_TESTS_SKIP=true make testrace PKG=./pkg/util/failsuite/... TESTTIMEOUT=45m TESTFLAGS=-v -json USE_ROCKSDB_ASSERTIONS=1
+GOPATH set to /go
+rm -rf /go/native/x86_64-pc-linux-gnu/rocksdb_assert
+mkdir -p /go/native/x86_64-pc-linux-gnu/rocksdb_assert
+cd /go/native/x86_64-pc-linux-gnu/rocksdb_assert && CFLAGS+=" -msse3" && CXXFLAGS+=" -msse3" && cmake -DCMAKE_TARGET_MESSAGES=OFF   /go/src/github.com/cockroachdb/cockroach/c-deps/rocksdb \
+   -DWITH_GFLAGS=OFF \
+  -DSNAPPY_LIBRARIES=/go/native/x86_64-pc-linux-gnu/snappy/libsnappy.a -DSNAPPY_INCLUDE_DIR="/go/src/github.com/cockroachdb/cockroach/c-deps/snappy;/go/native/x86_64-pc-linux-gnu/snappy" -DWITH_SNAPPY=ON \
+  -DJEMALLOC_LIBRARIES=/go/native/x86_64-pc-linux-gnu/jemalloc/lib/libjemalloc.a -DJEMALLOC_INCLUDE_DIR=/go/native/x86_64-pc-linux-gnu/jemalloc/include -DWITH_JEMALLOC=ON \
+  -DCMAKE_BUILD_TYPE=Release
+-- The C compiler identification is Clang 3.8.0
+-- The CXX compiler identification is Clang 3.8.0
+-- Check for working C compiler: /usr/lib/ccache/cc
+-- Check for working C compiler: /usr/lib/ccache/cc -- works
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Check for working CXX compiler: /usr/lib/ccache/c++
+-- Check for working CXX compiler: /usr/lib/ccache/c++ -- works
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- The ASM compiler identification is Clang
+-- Found assembler: /usr/lib/ccache/cc
+-- Found jemalloc: /go/native/x86_64-pc-linux-gnu/jemalloc/lib/libjemalloc.a  
+-- Found snappy: /go/native/x86_64-pc-linux-gnu/snappy/libsnappy.a  
+-- Found Git: /usr/bin/git (found version "2.7.4") 
+-- Performing Test HAVE_OMIT_LEAF_FRAME_POINTER
+-- Performing Test HAVE_OMIT_LEAF_FRAME_POINTER - Success
+-- Performing Test HAVE_SSE42
+-- Performing Test HAVE_SSE42 - Success
+-- Performing Test HAVE_THREAD_LOCAL
+-- Performing Test HAVE_THREAD_LOCAL - Success
+-- Could NOT find NUMA (missing:  NUMA_LIBRARIES NUMA_INCLUDE_DIR) 
+-- Could NOT find TBB (missing:  TBB_LIBRARIES TBB_INCLUDE_DIR) 
+-- Performing Test HAVE_FALLOCATE
+-- Performing Test HAVE_FALLOCATE - Success
+-- Performing Test HAVE_SYNC_FILE_RANGE_WRITE
+-- Performing Test HAVE_SYNC_FILE_RANGE_WRITE - Success
+-- Performing Test HAVE_PTHREAD_MUTEX_ADAPTIVE_NP
+-- Performing Test HAVE_PTHREAD_MUTEX_ADAPTIVE_NP - Success
+-- Looking for malloc_usable_size
+-- Looking for malloc_usable_size - found
+-- Looking for sched_getcpu
+-- Looking for sched_getcpu - found
+-- Looking for pthread.h
+-- Looking for pthread.h - found
+-- Looking for pthread_create
+-- Looking for pthread_create - not found
+-- Looking for pthread_create in pthreads
+-- Looking for pthread_create in pthreads - not found
+-- Looking for pthread_create in pthread
+-- Looking for pthread_create in pthread - found
+-- Found Threads: TRUE  
+-- JNI library is disabled
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /go/native/x86_64-pc-linux-gnu/rocksdb_assert
+Scanning dependencies of target build_version
+[  0%] Building CXX object CMakeFiles/build_version.dir/build_version.cc.o
+Scanning dependencies of target rocksdb
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/cache/clock_cache.cc.o
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/cache/lru_cache.cc.o
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/cache/sharded_cache.cc.o
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/db/builder.cc.o
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/db/c.cc.o
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/db/column_family.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compacted_db_impl.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction_iterator.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction_job.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction_picker.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction_picker_universal.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/convenience.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_filesnapshot.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_write.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_compaction_flush.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_files.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_open.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_debug.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_experimental.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_readonly.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/db_info_dumper.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/db_iter.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/dbformat.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/event_helpers.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/experimental.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/external_sst_file_ingestion_job.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/file_indexer.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/flush_job.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/flush_scheduler.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/forward_iterator.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/internal_stats.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/log_reader.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/log_writer.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/malloc_stats.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/managed_iterator.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/memtable.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/memtable_list.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/merge_helper.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/merge_operator.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/range_del_aggregator.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/repair.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/snapshot_impl.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/table_cache.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/table_properties_collector.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/transaction_log_impl.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/version_builder.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/version_edit.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/version_set.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/wal_manager.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/write_batch.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/write_batch_base.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/write_controller.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/write_thread.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/env/env.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/env/env_chroot.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/env/env_encryption.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/env/env_hdfs.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/env/mock_env.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/memtable/alloc_tracker.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/memtable/hash_cuckoo_rep.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/memtable/hash_linklist_rep.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/memtable/hash_skiplist_rep.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/memtable/skiplistrep.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/memtable/vectorrep.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/memtable/write_buffer_manager.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/histogram.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/histogram_windowing.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/instrumented_mutex.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/iostats_context.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/perf_context.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/perf_level.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/statistics.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_impl.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_updater.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_util.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_util_debug.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/options/cf_options.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/options/db_options.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/options/options.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/options/options_helper.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/options/options_parser.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/options/options_sanity_check.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/port/stack_trace.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/table/adaptive_table_factory.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/table/block.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based_filter_block.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based_table_builder.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based_table_factory.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based_table_reader.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_builder.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_fetcher.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_prefix_index.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/bloom_block.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/cuckoo_table_builder.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/cuckoo_table_factory.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/cuckoo_table_reader.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/flush_block_policy.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/format.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/full_filter_block.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/get_context.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/index_builder.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/iterator.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/merging_iterator.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/meta_blocks.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/partitioned_filter_block.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/persistent_cache_helper.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/plain_table_builder.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/plain_table_factory.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/plain_table_index.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/plain_table_key_coding.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/plain_table_reader.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/sst_file_writer.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/table_properties.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/two_level_iterator.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/tools/db_bench_tool.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/tools/dump/db_dump_tool.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/tools/ldb_cmd.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/tools/ldb_tool.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/tools/sst_dump_tool.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/util/arena.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/util/auto_roll_logger.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/util/bloom.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/coding.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/compaction_job_stats_impl.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/comparator.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/concurrent_arena.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/crc32c.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/delete_scheduler.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/dynamic_bloom.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/event_logger.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/file_reader_writer.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/file_util.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/filename.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/filter_policy.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/hash.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/log_buffer.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/murmurhash.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/random.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/rate_limiter.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/slice.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/sst_file_manager_impl.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/status.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/status_message.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/string_util.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/sync_point.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/testutil.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/thread_local.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/threadpool_imp.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/transaction_test_util.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/xxhash.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/utilities/backupable/backupable_db.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_compaction_filter.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_db.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_db_impl.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_dump_tool.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_file.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_log_reader.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_log_writer.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_log_format.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/ttl_extractor.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/cassandra/cassandra_compaction_filter.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/cassandra/format.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/cassandra/merge_operator.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/checkpoint/checkpoint_impl.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/col_buf_decoder.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/col_buf_encoder.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/column_aware_encoding_util.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/date_tiered/date_tiered_db_impl.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/debug.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/document/document_db.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/document/json_document.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/document/json_document_builder.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/env_mirror.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/env_timed.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/geodb/geodb_impl.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/leveldb_options/leveldb_options.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/lua/rocks_lua_compaction_filter.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/memory/memory_util.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/bytesxor.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/max.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/put.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/string_append/stringappend.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/string_append/stringappend2.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/uint64add.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/option_change_migration/option_change_migration.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/options/options_util.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/block_cache_tier.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/block_cache_tier_file.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/block_cache_tier_metadata.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/persistent_cache_tier.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/volatile_tier_impl.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/redis/redis_lists.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/simulator_cache/sim_cache.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/spatialdb/spatial_db.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/table_properties_collectors/compact_on_deletion_collector.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/optimistic_transaction_db_impl.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/optimistic_transaction.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/pessimistic_transaction.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/pessimistic_transaction_db.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/snapshot_checker.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/transaction_base.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/transaction_db_mutex_impl.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/transaction_lock_mgr.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/transaction_util.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/write_prepared_txn.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/write_prepared_txn_db.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/ttl/db_ttl_impl.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/write_batch_with_index/write_batch_with_index.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/write_batch_with_index/write_batch_with_index_internal.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/port/port_posix.cc.o
+[100%] Building CXX object CMakeFiles/rocksdb.dir/env/env_posix.cc.o
+[100%] Building CXX object CMakeFiles/rocksdb.dir/env/io_posix.cc.o
+[100%] Linking CXX static library librocksdb.a
+github.com/cockroachdb/cockroach/vendor/github.com/armon/go-radix
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/paths
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/utilities
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/ttycolor
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/ast/astutil
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/go/printer
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/internal/fastwalk
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/stress
+github.com/cockroachdb/cockroach/vendor/github.com/client9/misspell
+github.com/cockroachdb/cockroach/vendor/github.com/Masterminds/semver
+github.com/cockroachdb/cockroach/vendor/github.com/Masterminds/vcs
+github.com/cockroachdb/cockroach/vendor/github.com/boltdb/bolt
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/proto
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/cmd/gofmt
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/imports
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/go/format
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/pkgtree
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/imports
+github.com/cockroachdb/cockroach/vendor/github.com/pkg/errors
+github.com/cockroachdb/cockroach/vendor/github.com/jmank88/nuts
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/fs
+github.com/cockroachdb/cockroach/vendor/github.com/nightlyone/lockfile
+github.com/cockroachdb/cockroach/vendor/github.com/sdboyer/constext
+github.com/cockroachdb/cockroach/vendor/golang.org/x/net/context
+github.com/cockroachdb/cockroach/vendor/github.com/pelletier/go-toml
+github.com/cockroachdb/cockroach/vendor/gopkg.in/yaml.v2
+github.com/cockroachdb/cockroach/vendor/golang.org/x/sync/errgroup
+github.com/cockroachdb/cockroach/vendor/github.com/client9/misspell/cmd/misspell
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/gcimporter15
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/crlfmt
+github.com/cockroachdb/cockroach/vendor/github.com/golang/glog
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/internal/pb
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/cmd/goimports
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/generator/internal/remap
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/gcexportdata
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/plugin
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/httprule
+github.com/cockroachdb/cockroach/vendor/github.com/golang/lint
+github.com/cockroachdb/cockroach/vendor/google.golang.org/genproto/googleapis/api/annotations
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/generator
+github.com/cockroachdb/cockroach/vendor/github.com/jteeuwen/go-bindata
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/buildutil
+github.com/cockroachdb/cockroach/vendor/github.com/jteeuwen/go-bindata/go-bindata
+github.com/cockroachdb/cockroach/vendor/github.com/golang/lint/golint
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/loader
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/gotool/internal/load
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/gotool
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cover
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/errcheck/internal/errcheck
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/suffixtree
+github.com/cockroachdb/cockroach/vendor/github.com/mattn/goveralls
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/syntax
+github.com/cockroachdb/cockroach/vendor/github.com/wadey/gocovmerge
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/syntax/golang
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/errcheck
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/output
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/job
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/internal/stats
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/verify
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/feedback
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/storage/benchfmt
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cmd/goyacc
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/benchstat
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cmd/stringer
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/generator
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/cmd/benchstat
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/gengateway
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/base
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/glock
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/godep
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/glide
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/govend
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/govendor
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/gvt
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/vndr
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/cmd/dep
+touch bin/.bootstrap
+go install -v protoc-gen-gogoroach
+bin/prereqs ./pkg/cmd/protoc-gen-gogoroach > bin/protoc-gen-gogoroach.d.tmp
+mv -f bin/protoc-gen-gogoroach.d.tmp bin/protoc-gen-gogoroach.d
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/proto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/descriptor
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/plugin
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/gogoproto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/vanity
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/generator
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/testgen
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/defaultcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/embedcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/enumstringer
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/oneofcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/marshalto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/populate
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/unmarshal
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/grpc
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/compare
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/description
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/face
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/stringer
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/equal
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/size
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/gostring
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/union
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/vanity/command
+github.com/cockroachdb/cockroach/pkg/cmd/protoc-gen-gogoroach
+find ./pkg -name node_modules -prune -o -type f -name '*.pb.go' -exec rm {} +
+set -e; for dir in ./pkg/acceptance/cluster/ ./pkg/build/ ./pkg/ccl/backupccl/ ./pkg/ccl/baseccl/ ./pkg/ccl/storageccl/engineccl/enginepbccl/ ./pkg/ccl/utilccl/licenseccl/ ./pkg/config/ ./pkg/gossip/ ./pkg/internal/client/ ./pkg/jobs/jobspb/ ./pkg/roachpb/ ./pkg/rpc/ ./pkg/server/diagnosticspb/ ./pkg/server/serverpb/ ./pkg/server/status/ ./pkg/settings/cluster/ ./pkg/sql/distsqlrun/ ./pkg/sql/pgwire/pgerror/ ./pkg/sql/sqlbase/ ./pkg/sql/stats/ ./pkg/storage/ ./pkg/storage/closedts/ctpb/ ./pkg/storage/engine/enginepb/ ./pkg/storage/storagebase/ ./pkg/ts/tspb/ ./pkg/util/ ./pkg/util/hlc/ ./pkg/util/log/ ./pkg/util/metric/ ./pkg/util/protoutil/ ./pkg/util/tracing/; do \
+  build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --gogoroach_out=Mgoogle/api/annotations.proto=github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,,plugins=grpc,import_prefix=github.com/cockroachdb/cockroach/pkg/:./pkg $dir/*.proto; \
+done
+sed -i '/import _/d' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!import (fmt|math) "github.com/cockroachdb/cockroach/pkg/(fmt|math)"! !g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!github\.com/cockroachdb/cockroach/pkg/(etcd)!go.etcd.io/\1!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!cockroachdb/cockroach/pkg/(prometheus/client_model)!\1/go!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!github.com/cockroachdb/cockroach/pkg/(bytes|encoding/binary|errors|fmt|io|math|github\.com|(google\.)?golang\.org)!\1!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!golang.org/x/net/context!context!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+gofmt -s -w ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+touch bin/.go_protobuf_sources
+find ./pkg -name node_modules -prune -o -type f -name '*.pb.gw.go' -exec rm {} +
+build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true,request_context=true:./pkg ./pkg/server/serverpb/admin.proto ./pkg/server/serverpb/status.proto ./pkg/server/serverpb/authentication.proto
+build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true,request_context=true:./pkg ./pkg/ts/tspb/timeseries.proto
+sed -i -E 's!golang.org/x/net/context!context!g' ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+gofmt -s -w ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+goimports -w ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+touch bin/.gw_protobuf_sources
+mkdir -p pkg/sql/parser/gen
+set -euo pipefail; \
+TYPES=$(awk '/func.*sqlSymUnion/ {print $(NF - 1)}' pkg/sql/parser/sql.y | sed -e 's/[]\/$*.^|[]/\\&/g' | tr '\n' '|' | sed -E '$s/.$//'); \
+sed -E "s_(type|token) <($TYPES)>_\1 <union> /* <\2> */_" < pkg/sql/parser/sql.y | \
+awk -f pkg/sql/parser/replace_help_rules.awk | \
+sed -Ee 's,//.*$,,g;s,/[*]([^*]|[*][^/])*[*]/, ,g;s/ +$//g' > pkg/sql/parser/gen/sql-gen.y.tmp || rm pkg/sql/parser/gen/sql-gen.y.tmp
+mv -f pkg/sql/parser/gen/sql-gen.y.tmp pkg/sql/parser/gen/sql-gen.y
+set -euo pipefail; \
+  ret=$(cd pkg/sql/parser/gen && goyacc -p sql -o sql.go.tmp sql-gen.y); \
+  if expr "$ret" : ".*conflicts" >/dev/null; then \
+    echo "$ret"; exit 1; \
+  fi
+(echo "// Code generated by goyacc. DO NOT EDIT."; \
+ echo "// GENERATED FILE DO NOT EDIT"; \
+ cat pkg/sql/parser/gen/sql.go.tmp | \
+ sed -E 's/^const ([A-Z][_A-Z0-9]*) =.*$/const \1 = lex.\1/g') > pkg/sql/parser/sql.go.tmp || rm pkg/sql/parser/sql.go.tmp
+mv -f pkg/sql/parser/sql.go.tmp pkg/sql/parser/sql.go
+goimports -w pkg/sql/parser/sql.go
+mv -f pkg/sql/parser/helpmap_test.go.tmp pkg/sql/parser/helpmap_test.go
+gofmt -s -w pkg/sql/parser/helpmap_test.go
+awk -f pkg/sql/parser/help.awk < pkg/sql/parser/sql.y > pkg/sql/parser/help_messages.go.tmp || rm pkg/sql/parser/help_messages.go.tmp
+mv -f pkg/sql/parser/help_messages.go.tmp pkg/sql/parser/help_messages.go
+gofmt -s -w pkg/sql/parser/help_messages.go
+(echo "// Code generated by make. DO NOT EDIT."; \
+ echo "// GENERATED FILE DO NOT EDIT"; \
+ echo; \
+ echo "package lex"; \
+ echo; \
+ grep '^const [A-Z][_A-Z0-9]* ' pkg/sql/parser/gen/sql.go.tmp) > pkg/sql/lex/tokens.go.tmp || rm pkg/sql/lex/tokens.go.tmp
+mv -f pkg/sql/lex/tokens.go.tmp pkg/sql/lex/tokens.go
+awk -f pkg/sql/parser/all_keywords.awk < pkg/sql/parser/sql.y > pkg/sql/lex/keywords.go.tmp || rm pkg/sql/lex/keywords.go.tmp
+mv -f pkg/sql/lex/keywords.go.tmp pkg/sql/lex/keywords.go
+gofmt -s -w pkg/sql/lex/keywords.go
+awk -f pkg/sql/parser/reserved_keywords.awk < pkg/sql/parser/sql.y > pkg/sql/lex/reserved_keywords.go.tmp || rm pkg/sql/lex/reserved_keywords.go.tmp
+mv -f pkg/sql/lex/reserved_keywords.go.tmp pkg/sql/lex/reserved_keywords.go
+gofmt -s -w pkg/sql/lex/reserved_keywords.go
+go install -v optgen
+bin/prereqs ./pkg/sql/opt/optgen/cmd/optgen > bin/optgen.d.tmp
+mv -f bin/optgen.d.tmp bin/optgen.d
+github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang
+github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/cmd/optgen
+optgen -out pkg/sql/opt/memo/expr.og.go exprs pkg/sql/opt/ops/*.opt
+optgen -out pkg/sql/opt/operator.og.go ops pkg/sql/opt/ops/*.opt
+optgen -out pkg/sql/opt/xform/explorer.og.go explorer pkg/sql/opt/ops/*.opt pkg/sql/opt/xform/rules/*.opt
+optgen -out pkg/sql/opt/norm/factory.og.go factory pkg/sql/opt/ops/*.opt pkg/sql/opt/norm/rules/*.opt
+optgen -out pkg/sql/opt/rule_name.og.go rulenames pkg/sql/opt/ops/*.opt pkg/sql/opt/norm/rules/*.opt pkg/sql/opt/xform/rules/*.opt
+stringer -output=pkg/sql/opt/rule_name_string.go -type=RuleName pkg/sql/opt/rule_name.go pkg/sql/opt/rule_name.og.go
+go test -race -tags ' make x86_64_pc_linux_gnu' -ldflags '-X github.com/cockroachdb/cockroach/pkg/build.typ=development -extldflags "" -X "github.com/cockroachdb/cockroach/pkg/build.tag=v2.2.0-alpha.00000000-925-g3baa3d9" -X "github.com/cockroachdb/cockroach/pkg/build.rev=3baa3d9b299a392b7d9b737dbfb333d095e672a9" -X "github.com/cockroachdb/cockroach/pkg/build.cgoTargetTriple=x86_64-pc-linux-gnu"  ' -run "."  -timeout 45m ./pkg/util/failsuite/... -v -json
+{"Time":"2018-09-19T14:16:15.348540931Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatPasses"}
+{"Time":"2018-09-19T14:16:15.348696171Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatPasses","Output":"=== RUN   TestThatPasses\n"}
+{"Time":"2018-09-19T14:16:15.348711474Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatPasses","Output":"output of TestThatPasses\n"}
+{"Time":"2018-09-19T14:16:15.348757652Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatPasses","Output":"--- PASS: TestThatPasses (0.00s)\n"}
+{"Time":"2018-09-19T14:16:15.348813938Z","Action":"pass","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatPasses","Elapsed":0}
+{"Time":"2018-09-19T14:16:15.348833491Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails"}
+{"Time":"2018-09-19T14:16:15.348840851Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails","Output":"=== RUN   TestThatFails\n"}
+{"Time":"2018-09-19T14:16:15.349103824Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails","Output":"--- FAIL: TestThatFails (0.00s)\n"}
+{"Time":"2018-09-19T14:16:15.349153233Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails","Output":"\tmain_test.go:41: an error occurs\n"}
+{"Time":"2018-09-19T14:16:15.349174523Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails","Output":"\tmain_test.go:42: then the test fatals\n"}
+{"Time":"2018-09-19T14:16:15.349204229Z","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatFails","Elapsed":0}
+{"Time":"2018-09-19T14:16:15.349226807Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped"}
+{"Time":"2018-09-19T14:16:15.349234023Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped","Output":"=== RUN   TestThatGetsSkipped\n"}
+{"Time":"2018-09-19T14:16:15.349468553Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped","Output":"--- SKIP: TestThatGetsSkipped (0.00s)\n"}
+{"Time":"2018-09-19T14:16:15.349486443Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped","Output":"\tmain_test.go:46: logging something\n"}
+{"Time":"2018-09-19T14:16:15.349494948Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped","Output":"\tmain_test.go:47: skipped\n"}
+{"Time":"2018-09-19T14:16:15.349502432Z","Action":"skip","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestThatGetsSkipped","Elapsed":0}
+{"Time":"2018-09-19T14:16:15.349513194Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures"}
+{"Time":"2018-09-19T14:16:15.34952379Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures\n"}
+{"Time":"2018-09-19T14:16:15.349611282Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures","Output":"output before calling t.Parallel()\n"}
+{"Time":"2018-09-19T14:16:15.349626951Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures\n"}
+{"Time":"2018-09-19T14:16:15.349637571Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures"}
+{"Time":"2018-09-19T14:16:15.349646586Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures"}
+{"Time":"2018-09-19T14:16:15.349652985Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures","Output":"=== RUN   TestParallelWithDataRaceAndFailures\n"}
+{"Time":"2018-09-19T14:16:15.349858675Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures","Output":"output before calling t.Parallel()\n"}
+{"Time":"2018-09-19T14:16:15.349901331Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures","Output":"=== PAUSE TestParallelWithDataRaceAndFailures\n"}
+{"Time":"2018-09-19T14:16:15.349914296Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures"}
+{"Time":"2018-09-19T14:16:15.350076722Z","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures"}
+{"Time":"2018-09-19T14:16:15.350088109Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures\n"}
+{"Time":"2018-09-19T14:16:15.350134698Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0"}
+{"Time":"2018-09-19T14:16:15.350146007Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/0\n"}
+{"Time":"2018-09-19T14:16:15.350238518Z","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures"}
+{"Time":"2018-09-19T14:16:15.350253096Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures","Output":"=== CONT  TestParallelWithDataRaceAndFailures\n"}
+{"Time":"2018-09-19T14:16:15.351009294Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0"}
+{"Time":"2018-09-19T14:16:15.351044657Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0","Output":"=== RUN   TestParallelWithDataRaceAndFailures/0\n"}
+{"Time":"2018-09-19T14:16:15.351084743Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/0\n"}
+{"Time":"2018-09-19T14:16:15.35110435Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/0"}
+{"Time":"2018-09-19T14:16:15.351160089Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1"}
+{"Time":"2018-09-19T14:16:15.351172567Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/1\n"}
+{"Time":"2018-09-19T14:16:15.351453807Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/1\n"}
+{"Time":"2018-09-19T14:16:15.351481505Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1"}
+{"Time":"2018-09-19T14:16:15.351501585Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2"}
+{"Time":"2018-09-19T14:16:15.351511737Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/2\n"}
+{"Time":"2018-09-19T14:16:15.35163377Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/0\n"}
+{"Time":"2018-09-19T14:16:15.351655078Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/0"}
+{"Time":"2018-09-19T14:16:15.351673523Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1"}
+{"Time":"2018-09-19T14:16:15.35168373Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1","Output":"=== RUN   TestParallelWithDataRaceAndFailures/1\n"}
+{"Time":"2018-09-19T14:16:15.351810186Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/2\n"}
+{"Time":"2018-09-19T14:16:15.351842208Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/2"}
+{"Time":"2018-09-19T14:16:15.351859702Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3"}
+{"Time":"2018-09-19T14:16:15.351868465Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/3\n"}
+{"Time":"2018-09-19T14:16:15.351899587Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/1\n"}
+{"Time":"2018-09-19T14:16:15.351915455Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/1"}
+{"Time":"2018-09-19T14:16:15.351971301Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2"}
+{"Time":"2018-09-19T14:16:15.351997963Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2","Output":"=== RUN   TestParallelWithDataRaceAndFailures/2\n"}
+{"Time":"2018-09-19T14:16:15.35209551Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/3\n"}
+{"Time":"2018-09-19T14:16:15.35211388Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/3"}
+{"Time":"2018-09-19T14:16:15.352157061Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4"}
+{"Time":"2018-09-19T14:16:15.352175963Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/4\n"}
+{"Time":"2018-09-19T14:16:15.3522484Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/2\n"}
+{"Time":"2018-09-19T14:16:15.352261458Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/2"}
+{"Time":"2018-09-19T14:16:15.352333204Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3"}
+{"Time":"2018-09-19T14:16:15.352348646Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3","Output":"=== RUN   TestParallelWithDataRaceAndFailures/3\n"}
+{"Time":"2018-09-19T14:16:15.352413128Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/4\n"}
+{"Time":"2018-09-19T14:16:15.352424811Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/4"}
+{"Time":"2018-09-19T14:16:15.352449484Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5"}
+{"Time":"2018-09-19T14:16:15.352457523Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/5\n"}
+{"Time":"2018-09-19T14:16:15.352570998Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/3\n"}
+{"Time":"2018-09-19T14:16:15.352583579Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/3"}
+{"Time":"2018-09-19T14:16:15.352644417Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4"}
+{"Time":"2018-09-19T14:16:15.352655504Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4","Output":"=== RUN   TestParallelWithDataRaceAndFailures/4\n"}
+{"Time":"2018-09-19T14:16:15.352663952Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/5\n"}
+{"Time":"2018-09-19T14:16:15.35267247Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/5"}
+{"Time":"2018-09-19T14:16:15.352728028Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6"}
+{"Time":"2018-09-19T14:16:15.352737172Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/6\n"}
+{"Time":"2018-09-19T14:16:15.352895717Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/4\n"}
+{"Time":"2018-09-19T14:16:15.352907849Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/4"}
+{"Time":"2018-09-19T14:16:15.352946434Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5"}
+{"Time":"2018-09-19T14:16:15.352977523Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5","Output":"=== RUN   TestParallelWithDataRaceAndFailures/5\n"}
+{"Time":"2018-09-19T14:16:15.353087146Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/6\n"}
+{"Time":"2018-09-19T14:16:15.353140972Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/6"}
+{"Time":"2018-09-19T14:16:15.353161872Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7"}
+{"Time":"2018-09-19T14:16:15.353180183Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/7\n"}
+{"Time":"2018-09-19T14:16:15.353217495Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/5\n"}
+{"Time":"2018-09-19T14:16:15.353228447Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/5"}
+{"Time":"2018-09-19T14:16:15.353238969Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6"}
+{"Time":"2018-09-19T14:16:15.353248063Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6","Output":"=== RUN   TestParallelWithDataRaceAndFailures/6\n"}
+{"Time":"2018-09-19T14:16:15.353414991Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/7\n"}
+{"Time":"2018-09-19T14:16:15.353427698Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/7"}
+{"Time":"2018-09-19T14:16:15.353517072Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8"}
+{"Time":"2018-09-19T14:16:15.353536389Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/8\n"}
+{"Time":"2018-09-19T14:16:15.353544041Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/6\n"}
+{"Time":"2018-09-19T14:16:15.353549619Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/6"}
+{"Time":"2018-09-19T14:16:15.353556808Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7"}
+{"Time":"2018-09-19T14:16:15.353567727Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7","Output":"=== RUN   TestParallelWithDataRaceAndFailures/7\n"}
+{"Time":"2018-09-19T14:16:15.353791677Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/8\n"}
+{"Time":"2018-09-19T14:16:15.353806111Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8"}
+{"Time":"2018-09-19T14:16:15.353829127Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9"}
+{"Time":"2018-09-19T14:16:15.353846077Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9","Output":"=== RUN   TestParallelOneWithDataRaceWithoutFailures/9\n"}
+{"Time":"2018-09-19T14:16:15.353910416Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7","Output":"=== PAUSE TestParallelWithDataRaceAndFailures/7\n"}
+{"Time":"2018-09-19T14:16:15.353921266Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/7"}
+{"Time":"2018-09-19T14:16:15.353926984Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/8"}
+{"Time":"2018-09-19T14:16:15.353963444Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelWithDataRaceAndFailures/8","Output":"=== RUN   TestParallelWithDataRaceAndFailures/8\n"}
+{"Time":"2018-09-19T14:16:15.354071934Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9","Output":"=== PAUSE TestParallelOneWithDataRaceWithoutFailures/9\n"}
+{"Time":"2018-09-19T14:16:15.354102893Z","Action":"pause","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/9"}
+{"Time":"2018-09-19T14:16:15.354120774Z","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1"}
+{"Time":"2018-09-19T14:16:15.354133404Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/1","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/1\n"}
+{"Time":"2018-09-19T14:16:15.354149307Z","Action":"cont","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8"}
+{"Time":"2018-09-19T14:16:15.354167961Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"=== CONT  TestParallelOneWithDataRaceWithoutFailures/8\n"}
+{"Time":"2018-09-19T14:16:15.354222457Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"==================\n"}
+{"Time":"2018-09-19T14:16:15.354236437Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"WARNING: DATA RACE\n"}
+{"Time":"2018-09-19T14:16:15.354247262Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"Write at 0x00c42009e3a5 by goroutine 28:\n"}
+{"Time":"2018-09-19T14:16:15.35425722Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  github.com/cockroachdb/cockroach/pkg/util/failsuite.testParallelImpl.func2()\n"}
+{"Time":"2018-09-19T14:16:15.354274926Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:73 +0x6e\n"}
+{"Time":"2018-09-19T14:16:15.354285567Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  testing.tRunner()\n"}
+{"Time":"2018-09-19T14:16:15.354298881Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /usr/local/go/src/testing/testing.go:777 +0x16d\n"}
+{"Time":"2018-09-19T14:16:15.354309804Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"\n"}
+{"Time":"2018-09-19T14:16:15.354315997Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"Previous write at 0x00c42009e3a5 by goroutine 14:\n"}
+{"Time":"2018-09-19T14:16:15.354329029Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  github.com/cockroachdb/cockroach/pkg/util/failsuite.testParallelImpl.func2()\n"}
+{"Time":"2018-09-19T14:16:15.354339915Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:73 +0x6e\n"}
+{"Time":"2018-09-19T14:16:15.354351614Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  testing.tRunner()\n"}
+{"Time":"2018-09-19T14:16:15.354364097Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /usr/local/go/src/testing/testing.go:777 +0x16d\n"}
+{"Time":"2018-09-19T14:16:15.354374415Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"\n"}
+{"Time":"2018-09-19T14:16:15.35439291Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"Goroutine 28 (running) created at:\n"}
+{"Time":"2018-09-19T14:16:15.354403663Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  testing.(*T).Run()\n"}
+{"Time":"2018-09-19T14:16:15.35441001Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /usr/local/go/src/testing/testing.go:824 +0x564\n"}
+{"Time":"2018-09-19T14:16:15.354422223Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  github.com/cockroachdb/cockroach/pkg/util/failsuite.testParallelImpl()\n"}
+{"Time":"2018-09-19T14:16:15.354440295Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:70 +0x111\n"}
+{"Time":"2018-09-19T14:16:15.354452107Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  github.com/cockroachdb/cockroach/pkg/util/failsuite.TestParallelOneWithDataRaceWithoutFailures()\n"}
+{"Time":"2018-09-19T14:16:15.354458415Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:51 +0x3d\n"}
+{"Time":"2018-09-19T14:16:15.354464289Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  testing.tRunner()\n"}
+{"Time":"2018-09-19T14:16:15.35447039Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /usr/local/go/src/testing/testing.go:777 +0x16d\n"}
+{"Time":"2018-09-19T14:16:15.354476352Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"\n"}
+{"Time":"2018-09-19T14:16:15.354486666Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"Goroutine 14 (running) created at:\n"}
+{"Time":"2018-09-19T14:16:15.354493188Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  testing.(*T).Run()\n"}
+{"Time":"2018-09-19T14:16:15.354498832Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /usr/local/go/src/testing/testing.go:824 +0x564\n"}
+{"Time":"2018-09-19T14:16:15.354504765Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  github.com/cockroachdb/cockroach/pkg/util/failsuite.testParallelImpl()\n"}
+{"Time":"2018-09-19T14:16:15.354526505Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:70 +0x111\n"}
+{"Time":"2018-09-19T14:16:15.354550874Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  github.com/cockroachdb/cockroach/pkg/util/failsuite.TestParallelOneWithDataRaceWithoutFailures()\n"}
+{"Time":"2018-09-19T14:16:15.354562533Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:51 +0x3d\n"}
+{"Time":"2018-09-19T14:16:15.354575996Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"  testing.tRunner()\n"}
+{"Time":"2018-09-19T14:16:15.354586068Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"      /usr/local/go/src/testing/testing.go:777 +0x16d\n"}
+{"Time":"2018-09-19T14:16:15.354602047Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"==================\n"}
+{"Time":"2018-09-19T14:16:15.356900909Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Output":"FAIL\tgithub.com/cockroachdb/cockroach/pkg/util/failsuite\t0.019s\n"}
+{"Time":"2018-09-19T14:16:15.356934437Z","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite","Test":"TestParallelOneWithDataRaceWithoutFailures/8","Elapsed":0.02}
+{"Time":"2018-09-19T14:16:15.373223064Z","Action":"run","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics"}
+{"Time":"2018-09-19T14:16:15.3732677Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"=== RUN   TestZPanics\n"}
+{"Time":"2018-09-19T14:16:15.373357947Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"first output something\n"}
+{"Time":"2018-09-19T14:16:15.373505202Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"--- FAIL: TestZPanics (0.00s)\n"}
+{"Time":"2018-09-19T14:16:15.373520564Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\tmain_test.go:35: then log something\n"}
+{"Time":"2018-09-19T14:16:15.373527379Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\tmain_test.go:36: an error, why not\n"}
+{"Time":"2018-09-19T14:16:15.376827464Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"panic: boom [recovered]\n"}
+{"Time":"2018-09-19T14:16:15.376874381Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\tpanic: boom\n"}
+{"Time":"2018-09-19T14:16:15.376881646Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\n"}
+{"Time":"2018-09-19T14:16:15.376897902Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"goroutine 20 [running]:\n"}
+{"Time":"2018-09-19T14:16:15.376903258Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.tRunner.func1(0xc4200ea1e0)\n"}
+{"Time":"2018-09-19T14:16:15.376908407Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:742 +0x567\n"}
+{"Time":"2018-09-19T14:16:15.37691988Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"panic(0x5b7860, 0x609a90)\n"}
+{"Time":"2018-09-19T14:16:15.376931684Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/runtime/panic.go:502 +0x24a\n"}
+{"Time":"2018-09-19T14:16:15.376941922Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic.TestZPanics(0xc4200ea1e0)\n"}
+{"Time":"2018-09-19T14:16:15.376952234Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic/main_test.go:37 +0x14b\n"}
+{"Time":"2018-09-19T14:16:15.376962636Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.tRunner(0xc4200ea1e0, 0x5f8dd8)\n"}
+{"Time":"2018-09-19T14:16:15.376968815Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:777 +0x16e\n"}
+{"Time":"2018-09-19T14:16:15.376974007Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"created by testing.(*T).Run\n"}
+{"Time":"2018-09-19T14:16:15.376984573Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:824 +0x565\n"}
+{"Time":"2018-09-19T14:16:15.376994396Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\n"}
+{"Time":"2018-09-19T14:16:15.377000617Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"goroutine 1 [chan receive]:\n"}
+{"Time":"2018-09-19T14:16:15.377019511Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.(*T).Run(0xc4200ea0f0, 0x5f0e98, 0xb, 0x5f8dd8, 0xc420069c38)\n"}
+{"Time":"2018-09-19T14:16:15.377036583Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:825 +0x597\n"}
+{"Time":"2018-09-19T14:16:15.377042432Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.runTests.func1(0xc4200ea0f0)\n"}
+{"Time":"2018-09-19T14:16:15.377051785Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:1063 +0xa5\n"}
+{"Time":"2018-09-19T14:16:15.377057358Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.tRunner(0xc4200ea0f0, 0xc420069d80)\n"}
+{"Time":"2018-09-19T14:16:15.377066884Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:777 +0x16e\n"}
+{"Time":"2018-09-19T14:16:15.377076623Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.runTests(0xc4200b0340, 0x6dda60, 0x1, 0x1, 0x0)\n"}
+{"Time":"2018-09-19T14:16:15.377085716Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:1061 +0x4e2\n"}
+{"Time":"2018-09-19T14:16:15.37709502Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"testing.(*M).Run(0xc4200ec000, 0x0)\n"}
+{"Time":"2018-09-19T14:16:15.377104526Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/usr/local/go/src/testing/testing.go:978 +0x2ce\n"}
+{"Time":"2018-09-19T14:16:15.377114133Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic.TestMain(0xc4200ec000)\n"}
+{"Time":"2018-09-19T14:16:15.377120008Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t/go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic/main_test.go:30 +0x60\n"}
+{"Time":"2018-09-19T14:16:15.377130302Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"main.main()\n"}
+{"Time":"2018-09-19T14:16:15.377136206Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"\t_testmain.go:40 +0x22b\n"}
+{"Time":"2018-09-19T14:16:15.377482595Z","Action":"output","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Output":"FAIL\tgithub.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic\t0.014s\n"}
+{"Time":"2018-09-19T14:16:15.377514652Z","Action":"fail","Package":"github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic","Test":"TestZPanics","Elapsed":0.014}
+make: *** [testrace] Error 1
+Makefile:830: recipe for target 'testrace' failed
+

--- a/testdata/output.json/test.json.txt
+++ b/testdata/output.json/test.json.txt
@@ -1,0 +1,402 @@
+build/builder.sh env TZ=America/New_York COCKROACH_FAILSUITE=true make test PKG=./pkg/util/failsuite/... TESTFLAGS=-v -json
+GOPATH set to /go
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/utilities
+github.com/cockroachdb/cockroach/vendor/github.com/armon/go-radix
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/paths
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/ttycolor
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/internal/fastwalk
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/ast/astutil
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/go/printer
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/stress
+github.com/cockroachdb/cockroach/vendor/github.com/client9/misspell
+github.com/cockroachdb/cockroach/vendor/github.com/Masterminds/semver
+github.com/cockroachdb/cockroach/vendor/github.com/Masterminds/vcs
+github.com/cockroachdb/cockroach/vendor/github.com/boltdb/bolt
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/proto
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/imports
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/cmd/gofmt
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/go/format
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/pkgtree
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/imports
+github.com/cockroachdb/cockroach/vendor/github.com/pkg/errors
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/fs
+github.com/cockroachdb/cockroach/vendor/github.com/jmank88/nuts
+github.com/cockroachdb/cockroach/vendor/github.com/nightlyone/lockfile
+github.com/cockroachdb/cockroach/vendor/github.com/sdboyer/constext
+github.com/cockroachdb/cockroach/vendor/golang.org/x/net/context
+github.com/cockroachdb/cockroach/vendor/github.com/pelletier/go-toml
+github.com/cockroachdb/cockroach/vendor/golang.org/x/sync/errgroup
+github.com/cockroachdb/cockroach/vendor/gopkg.in/yaml.v2
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/gcimporter15
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/crlfmt
+github.com/cockroachdb/cockroach/vendor/github.com/client9/misspell/cmd/misspell
+github.com/cockroachdb/cockroach/vendor/github.com/golang/glog
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/cmd/goimports
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/internal/pb
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/gcexportdata
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor
+github.com/cockroachdb/cockroach/vendor/github.com/golang/lint
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/generator/internal/remap
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/httprule
+github.com/cockroachdb/cockroach/vendor/github.com/jteeuwen/go-bindata
+github.com/cockroachdb/cockroach/vendor/github.com/golang/lint/golint
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/buildutil
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/plugin
+github.com/cockroachdb/cockroach/vendor/google.golang.org/genproto/googleapis/api/annotations
+github.com/cockroachdb/cockroach/vendor/github.com/jteeuwen/go-bindata/go-bindata
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/generator
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/loader
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/gotool/internal/load
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cover
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/gotool
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/suffixtree
+github.com/cockroachdb/cockroach/vendor/github.com/mattn/goveralls
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/errcheck/internal/errcheck
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/syntax
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/syntax/golang
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/output
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/errcheck
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/job
+github.com/cockroachdb/cockroach/vendor/github.com/wadey/gocovmerge
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/internal/stats
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/storage/benchfmt
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cmd/goyacc
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/benchstat
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/verify
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/feedback
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/cmd/benchstat
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cmd/stringer
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/generator
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/gengateway
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/base
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/glide
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/glock
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/govendor
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/govend
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/godep
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/gvt
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/vndr
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/cmd/dep
+touch bin/.bootstrap
+go install -v protoc-gen-gogoroach
+bin/prereqs ./pkg/cmd/protoc-gen-gogoroach > bin/protoc-gen-gogoroach.d.tmp
+mv -f bin/protoc-gen-gogoroach.d.tmp bin/protoc-gen-gogoroach.d
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/proto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/descriptor
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/plugin
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/gogoproto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/vanity
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/generator
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/defaultcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/testgen
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/unmarshal
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/marshalto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/embedcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/enumstringer
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/oneofcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/populate
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/grpc
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/description
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/compare
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/face
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/gostring
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/equal
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/size
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/stringer
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/union
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/vanity/command
+github.com/cockroachdb/cockroach/pkg/cmd/protoc-gen-gogoroach
+find ./pkg -name node_modules -prune -o -type f -name '*.pb.go' -exec rm {} +
+set -e; for dir in ./pkg/acceptance/cluster/ ./pkg/build/ ./pkg/ccl/backupccl/ ./pkg/ccl/baseccl/ ./pkg/ccl/storageccl/engineccl/enginepbccl/ ./pkg/ccl/utilccl/licenseccl/ ./pkg/config/ ./pkg/gossip/ ./pkg/internal/client/ ./pkg/jobs/jobspb/ ./pkg/roachpb/ ./pkg/rpc/ ./pkg/server/diagnosticspb/ ./pkg/server/serverpb/ ./pkg/server/status/ ./pkg/settings/cluster/ ./pkg/sql/distsqlrun/ ./pkg/sql/pgwire/pgerror/ ./pkg/sql/sqlbase/ ./pkg/sql/stats/ ./pkg/storage/ ./pkg/storage/closedts/ctpb/ ./pkg/storage/engine/enginepb/ ./pkg/storage/storagebase/ ./pkg/ts/tspb/ ./pkg/util/ ./pkg/util/hlc/ ./pkg/util/log/ ./pkg/util/metric/ ./pkg/util/protoutil/ ./pkg/util/tracing/; do \
+build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --gogoroach_out=Mgoogle/api/annotations.proto=github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,,plugins=grpc,import_prefix=github.com/cockroachdb/cockroach/pkg/:./pkg $dir/*.proto; \
+done
+sed -i '/import _/d' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!import (fmt|math) "github.com/cockroachdb/cockroach/pkg/(fmt|math)"! !g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!github\.com/cockroachdb/cockroach/pkg/(etcd)!go.etcd.io/\1!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!cockroachdb/cockroach/pkg/(prometheus/client_model)!\1/go!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!github.com/cockroachdb/cockroach/pkg/(bytes|encoding/binary|errors|fmt|io|math|github\.com|(google\.)?golang\.org)!\1!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!golang.org/x/net/context!context!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+gofmt -s -w ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+touch bin/.go_protobuf_sources
+find ./pkg -name node_modules -prune -o -type f -name '*.pb.gw.go' -exec rm {} +
+build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true,request_context=true:./pkg ./pkg/server/serverpb/admin.proto ./pkg/server/serverpb/status.proto ./pkg/server/serverpb/authentication.proto
+build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true,request_context=true:./pkg ./pkg/ts/tspb/timeseries.proto
+sed -i -E 's!golang.org/x/net/context!context!g' ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+gofmt -s -w ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+goimports -w ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+touch bin/.gw_protobuf_sources
+mkdir -p pkg/sql/parser/gen
+set -euo pipefail; \
+TYPES=$(awk '/func.*sqlSymUnion/ {print $(NF - 1)}' pkg/sql/parser/sql.y | sed -e 's/[]\/$*.^|[]/\\&/g' | tr '\n' '|' | sed -E '$s/.$//'); \
+sed -E "s_(type|token) <($TYPES)>_\1 <union> /* <\2> */_" < pkg/sql/parser/sql.y | \
+awk -f pkg/sql/parser/replace_help_rules.awk | \
+sed -Ee 's,//.*$,,g;s,/[*]([^*]|[*][^/])*[*]/, ,g;s/ +$//g' > pkg/sql/parser/gen/sql-gen.y.tmp || rm pkg/sql/parser/gen/sql-gen.y.tmp
+mv -f pkg/sql/parser/gen/sql-gen.y.tmp pkg/sql/parser/gen/sql-gen.y
+set -euo pipefail; \
+  ret=$(cd pkg/sql/parser/gen && goyacc -p sql -o sql.go.tmp sql-gen.y); \
+  if expr "$ret" : ".*conflicts" >/dev/null; then \
+    echo "$ret"; exit 1; \
+  fi
+(echo "// Code generated by goyacc. DO NOT EDIT."; \
+ echo "// GENERATED FILE DO NOT EDIT"; \
+ cat pkg/sql/parser/gen/sql.go.tmp | \
+ sed -E 's/^const ([A-Z][_A-Z0-9]*) =.*$/const \1 = lex.\1/g') > pkg/sql/parser/sql.go.tmp || rm pkg/sql/parser/sql.go.tmp
+mv -f pkg/sql/parser/sql.go.tmp pkg/sql/parser/sql.go
+goimports -w pkg/sql/parser/sql.go
+mv -f pkg/sql/parser/helpmap_test.go.tmp pkg/sql/parser/helpmap_test.go
+gofmt -s -w pkg/sql/parser/helpmap_test.go
+awk -f pkg/sql/parser/help.awk < pkg/sql/parser/sql.y > pkg/sql/parser/help_messages.go.tmp || rm pkg/sql/parser/help_messages.go.tmp
+mv -f pkg/sql/parser/help_messages.go.tmp pkg/sql/parser/help_messages.go
+gofmt -s -w pkg/sql/parser/help_messages.go
+(echo "// Code generated by make. DO NOT EDIT."; \
+ echo "// GENERATED FILE DO NOT EDIT"; \
+ echo; \
+ echo "package lex"; \
+ echo; \
+ grep '^const [A-Z][_A-Z0-9]* ' pkg/sql/parser/gen/sql.go.tmp) > pkg/sql/lex/tokens.go.tmp || rm pkg/sql/lex/tokens.go.tmp
+mv -f pkg/sql/lex/tokens.go.tmp pkg/sql/lex/tokens.go
+awk -f pkg/sql/parser/all_keywords.awk < pkg/sql/parser/sql.y > pkg/sql/lex/keywords.go.tmp || rm pkg/sql/lex/keywords.go.tmp
+mv -f pkg/sql/lex/keywords.go.tmp pkg/sql/lex/keywords.go
+gofmt -s -w pkg/sql/lex/keywords.go
+awk -f pkg/sql/parser/reserved_keywords.awk < pkg/sql/parser/sql.y > pkg/sql/lex/reserved_keywords.go.tmp || rm pkg/sql/lex/reserved_keywords.go.tmp
+mv -f pkg/sql/lex/reserved_keywords.go.tmp pkg/sql/lex/reserved_keywords.go
+gofmt -s -w pkg/sql/lex/reserved_keywords.go
+go install -v optgen
+bin/prereqs ./pkg/sql/opt/optgen/cmd/optgen > bin/optgen.d.tmp
+mv -f bin/optgen.d.tmp bin/optgen.d
+github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang
+github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/cmd/optgen
+optgen -out pkg/sql/opt/memo/expr.og.go exprs pkg/sql/opt/ops/*.opt
+optgen -out pkg/sql/opt/operator.og.go ops pkg/sql/opt/ops/*.opt
+optgen -out pkg/sql/opt/xform/explorer.og.go explorer pkg/sql/opt/ops/*.opt pkg/sql/opt/xform/rules/*.opt
+optgen -out pkg/sql/opt/norm/factory.og.go factory pkg/sql/opt/ops/*.opt pkg/sql/opt/norm/rules/*.opt
+optgen -out pkg/sql/opt/rule_name.og.go rulenames pkg/sql/opt/ops/*.opt pkg/sql/opt/norm/rules/*.opt pkg/sql/opt/xform/rules/*.opt
+stringer -output=pkg/sql/opt/rule_name_string.go -type=RuleName pkg/sql/opt/rule_name.go pkg/sql/opt/rule_name.og.go
+go test  -tags ' make x86_64_pc_linux_gnu' -ldflags '-X github.com/cockroachdb/cockroach/pkg/build.typ=development -extldflags "" -X "github.com/cockroachdb/cockroach/pkg/build.tag=v2.2.0-alpha.00000000-925-g3baa3d9" -X "github.com/cockroachdb/cockroach/pkg/build.rev=3baa3d9b299a392b7d9b737dbfb333d095e672a9" -X "github.com/cockroachdb/cockroach/pkg/build.cgoTargetTriple=x86_64-pc-linux-gnu"  ' -run "."  -timeout 8m ./pkg/util/failsuite/... -v -json
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestZPanics' captureStandardOutput='true']
+=== RUN   TestZPanics
+first output something
+--- FAIL: TestZPanics (0.00s)
+	main_test.go:35: then log something
+	main_test.go:36: an error, why not
+panic: boom [recovered]
+	panic: boom
+
+goroutine 6 [running]:
+testing.tRunner.func1(0xc4200d41e0)
+	/usr/local/go/src/testing/testing.go:742 +0x29d
+panic(0x51c5e0, 0x56c2b0)
+	/usr/local/go/src/runtime/panic.go:502 +0x229
+github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic.TestZPanics(0xc4200d41e0)
+	/go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic/main_test.go:37 +0x113
+testing.tRunner(0xc4200d41e0, 0x55c110)
+	/usr/local/go/src/testing/testing.go:777 +0xd0
+created by testing.(*T).Run
+	/usr/local/go/src/testing/testing.go:824 +0x2e0
+
+goroutine 1 [chan receive]:
+testing.(*T).Run(0xc4200d41e0, 0x554258, 0xb, 0x55c110, 0x473276)
+	/usr/local/go/src/testing/testing.go:825 +0x301
+testing.runTests.func1(0xc4200d40f0)
+	/usr/local/go/src/testing/testing.go:1063 +0x64
+testing.tRunner(0xc4200d40f0, 0xc420067dc8)
+	/usr/local/go/src/testing/testing.go:777 +0xd0
+testing.runTests(0xc42000c380, 0x609720, 0x1, 0x1, 0x0)
+	/usr/local/go/src/testing/testing.go:1061 +0x2c4
+testing.(*M).Run(0xc4200d6000, 0x0)
+	/usr/local/go/src/testing/testing.go:978 +0x171
+github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic.TestMain(0xc4200d6000)
+	/go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic/main_test.go:30 +0x52
+main.main()
+	_testmain.go:40 +0x151
+FAIL	github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic	0.006s
+##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestZPanics' details='']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestZPanics' duration='6']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestThatPasses' captureStandardOutput='true']
+=== RUN   TestThatPasses
+output of TestThatPasses
+--- PASS: TestThatPasses (0.00s)
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestThatPasses' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestThatFails' captureStandardOutput='true']
+=== RUN   TestThatFails
+--- FAIL: TestThatFails (0.00s)
+	main_test.go:41: an error occurs
+	main_test.go:42: then the test fatals
+##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestThatFails' details='']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestThatFails' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestThatGetsSkipped' captureStandardOutput='true']
+=== RUN   TestThatGetsSkipped
+--- SKIP: TestThatGetsSkipped (0.00s)
+	main_test.go:46: logging something
+	main_test.go:47: skipped
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestThatGetsSkipped']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/5' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/5
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/5
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/5
+    --- PASS: TestParallelOneWithDataRaceWithoutFailures/5 (0.14s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/5' duration='140']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/3' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/3
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/3
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/3
+    --- PASS: TestParallelOneWithDataRaceWithoutFailures/3 (0.21s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/3' duration='210']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/0' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/0
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/0
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/0
+    --- PASS: TestParallelOneWithDataRaceWithoutFailures/0 (0.30s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/0' duration='300']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/1' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/1
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/1
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/1
+    --- PASS: TestParallelOneWithDataRaceWithoutFailures/1 (0.11s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/1' duration='110']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/4' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/4
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/4
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/4
+    --- PASS: TestParallelOneWithDataRaceWithoutFailures/4 (0.34s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/4' duration='340']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/9' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/9
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/9
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/9
+    --- PASS: TestParallelOneWithDataRaceWithoutFailures/9 (0.43s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/9' duration='430']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/6' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/6
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/6
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/6
+    --- PASS: TestParallelOneWithDataRaceWithoutFailures/6 (0.48s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/6' duration='480']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/2' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/2
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/2
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/2
+    --- PASS: TestParallelOneWithDataRaceWithoutFailures/2 (0.65s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/2' duration='650']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/7' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/7
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/7
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/7
+    --- PASS: TestParallelOneWithDataRaceWithoutFailures/7 (0.91s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/7' duration='910']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/8' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/8
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/8
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/8
+    --- PASS: TestParallelOneWithDataRaceWithoutFailures/8 (0.94s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/8' duration='940']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures
+output before calling t.Parallel()
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures
+=== CONT  TestParallelOneWithDataRaceWithoutFailures
+--- PASS: TestParallelOneWithDataRaceWithoutFailures (0.00s)
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/6' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/6
+=== PAUSE TestParallelWithDataRaceAndFailures/6
+=== CONT  TestParallelWithDataRaceAndFailures/6
+    --- FAIL: TestParallelWithDataRaceAndFailures/6 (0.01s)
+    	main_test.go:81: subtest failed
+##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/6' details='']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/6' duration='10']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/9' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/9
+=== PAUSE TestParallelWithDataRaceAndFailures/9
+=== CONT  TestParallelWithDataRaceAndFailures/9
+    --- FAIL: TestParallelWithDataRaceAndFailures/9 (0.46s)
+    	main_test.go:81: subtest failed
+##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/9' details='']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/9' duration='460']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/0' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/0
+=== PAUSE TestParallelWithDataRaceAndFailures/0
+=== CONT  TestParallelWithDataRaceAndFailures/0
+    --- FAIL: TestParallelWithDataRaceAndFailures/0 (0.75s)
+    	main_test.go:81: subtest failed
+##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/0' details='']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/0' duration='750']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/5' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/5
+=== PAUSE TestParallelWithDataRaceAndFailures/5
+=== CONT  TestParallelWithDataRaceAndFailures/5
+    --- PASS: TestParallelWithDataRaceAndFailures/5 (0.61s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/5' duration='610']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/7' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/7
+=== PAUSE TestParallelWithDataRaceAndFailures/7
+=== CONT  TestParallelWithDataRaceAndFailures/7
+    --- PASS: TestParallelWithDataRaceAndFailures/7 (0.68s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/7' duration='680']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/8' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/8
+=== PAUSE TestParallelWithDataRaceAndFailures/8
+=== CONT  TestParallelWithDataRaceAndFailures/8
+    --- PASS: TestParallelWithDataRaceAndFailures/8 (0.82s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/8' duration='820']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/3' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/3
+=== PAUSE TestParallelWithDataRaceAndFailures/3
+=== CONT  TestParallelWithDataRaceAndFailures/3
+    --- FAIL: TestParallelWithDataRaceAndFailures/3 (0.46s)
+    	main_test.go:81: subtest failed
+##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/3' details='']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/3' duration='460']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/1' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/1
+=== PAUSE TestParallelWithDataRaceAndFailures/1
+=== CONT  TestParallelWithDataRaceAndFailures/1
+    --- PASS: TestParallelWithDataRaceAndFailures/1 (0.44s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/1' duration='440']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/2' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/2
+=== PAUSE TestParallelWithDataRaceAndFailures/2
+=== CONT  TestParallelWithDataRaceAndFailures/2
+    --- PASS: TestParallelWithDataRaceAndFailures/2 (0.47s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/2' duration='470']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/4' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/4
+=== PAUSE TestParallelWithDataRaceAndFailures/4
+=== CONT  TestParallelWithDataRaceAndFailures/4
+    --- PASS: TestParallelWithDataRaceAndFailures/4 (0.63s)
+    	main_test.go:83: something gets logged
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/4' duration='630']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures
+output before calling t.Parallel()
+=== PAUSE TestParallelWithDataRaceAndFailures
+=== CONT  TestParallelWithDataRaceAndFailures
+--- FAIL: TestParallelWithDataRaceAndFailures (0.00s)
+##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures' details='']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures' duration='0']
+FAIL
+FAIL	github.com/cockroachdb/cockroach/pkg/util/failsuite	1.409s
+make: *** [test] Error 1
+Makefile:830: recipe for target 'test' failed
+

--- a/testdata/output.json/testrace.json.txt
+++ b/testdata/output.json/testrace.json.txt
@@ -1,0 +1,682 @@
+build/builder.sh env COCKROACH_FAILSUITE=1 COCKROACH_LOGIC_TESTS_SKIP=true make testrace PKG=./pkg/util/failsuite/... TESTTIMEOUT=45m TESTFLAGS=-v -json USE_ROCKSDB_ASSERTIONS=1
+GOPATH set to /go
+rm -rf /go/native/x86_64-pc-linux-gnu/rocksdb_assert
+mkdir -p /go/native/x86_64-pc-linux-gnu/rocksdb_assert
+cd /go/native/x86_64-pc-linux-gnu/rocksdb_assert && CFLAGS+=" -msse3" && CXXFLAGS+=" -msse3" && cmake -DCMAKE_TARGET_MESSAGES=OFF   /go/src/github.com/cockroachdb/cockroach/c-deps/rocksdb \
+   -DWITH_GFLAGS=OFF \
+-DSNAPPY_LIBRARIES=/go/native/x86_64-pc-linux-gnu/snappy/libsnappy.a -DSNAPPY_INCLUDE_DIR="/go/src/github.com/cockroachdb/cockroach/c-deps/snappy;/go/native/x86_64-pc-linux-gnu/snappy" -DWITH_SNAPPY=ON \
+  -DJEMALLOC_LIBRARIES=/go/native/x86_64-pc-linux-gnu/jemalloc/lib/libjemalloc.a -DJEMALLOC_INCLUDE_DIR=/go/native/x86_64-pc-linux-gnu/jemalloc/include -DWITH_JEMALLOC=ON \
+  -DCMAKE_BUILD_TYPE=Release
+-- The C compiler identification is Clang 3.8.0
+-- The CXX compiler identification is Clang 3.8.0
+-- Check for working C compiler: /usr/lib/ccache/cc
+-- Check for working C compiler: /usr/lib/ccache/cc -- works
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Check for working CXX compiler: /usr/lib/ccache/c++
+-- Check for working CXX compiler: /usr/lib/ccache/c++ -- works
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- The ASM compiler identification is Clang
+-- Found assembler: /usr/lib/ccache/cc
+-- Found jemalloc: /go/native/x86_64-pc-linux-gnu/jemalloc/lib/libjemalloc.a  
+-- Found snappy: /go/native/x86_64-pc-linux-gnu/snappy/libsnappy.a  
+-- Found Git: /usr/bin/git (found version "2.7.4") 
+-- Performing Test HAVE_OMIT_LEAF_FRAME_POINTER
+-- Performing Test HAVE_OMIT_LEAF_FRAME_POINTER - Success
+-- Performing Test HAVE_SSE42
+-- Performing Test HAVE_SSE42 - Success
+-- Performing Test HAVE_THREAD_LOCAL
+-- Performing Test HAVE_THREAD_LOCAL - Success
+-- Could NOT find NUMA (missing:  NUMA_LIBRARIES NUMA_INCLUDE_DIR) 
+-- Could NOT find TBB (missing:  TBB_LIBRARIES TBB_INCLUDE_DIR) 
+-- Performing Test HAVE_FALLOCATE
+-- Performing Test HAVE_FALLOCATE - Success
+-- Performing Test HAVE_SYNC_FILE_RANGE_WRITE
+-- Performing Test HAVE_SYNC_FILE_RANGE_WRITE - Success
+-- Performing Test HAVE_PTHREAD_MUTEX_ADAPTIVE_NP
+-- Performing Test HAVE_PTHREAD_MUTEX_ADAPTIVE_NP - Success
+-- Looking for malloc_usable_size
+-- Looking for malloc_usable_size - found
+-- Looking for sched_getcpu
+-- Looking for sched_getcpu - found
+-- Looking for pthread.h
+-- Looking for pthread.h - found
+-- Looking for pthread_create
+-- Looking for pthread_create - not found
+-- Looking for pthread_create in pthreads
+-- Looking for pthread_create in pthreads - not found
+-- Looking for pthread_create in pthread
+-- Looking for pthread_create in pthread - found
+-- Found Threads: TRUE  
+-- JNI library is disabled
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /go/native/x86_64-pc-linux-gnu/rocksdb_assert
+Scanning dependencies of target build_version
+[  0%] Building CXX object CMakeFiles/build_version.dir/build_version.cc.o
+Scanning dependencies of target rocksdb
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/cache/clock_cache.cc.o
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/cache/lru_cache.cc.o
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/cache/sharded_cache.cc.o
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/db/builder.cc.o
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/db/c.cc.o
+[  0%] Building CXX object CMakeFiles/rocksdb.dir/db/column_family.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compacted_db_impl.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction_iterator.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction_job.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction_picker.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction_picker_universal.cc.o
+[  3%] Building CXX object CMakeFiles/rocksdb.dir/db/convenience.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_filesnapshot.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_write.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_compaction_flush.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_files.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_open.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_debug.cc.o
+[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_experimental.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl_readonly.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/db_info_dumper.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/db_iter.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/dbformat.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/event_helpers.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/experimental.cc.o
+[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/external_sst_file_ingestion_job.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/file_indexer.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/flush_job.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/flush_scheduler.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/forward_iterator.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/internal_stats.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/log_reader.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/log_writer.cc.o
+[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/malloc_stats.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/managed_iterator.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/memtable.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/memtable_list.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/merge_helper.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/merge_operator.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/range_del_aggregator.cc.o
+[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/repair.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/snapshot_impl.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/table_cache.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/table_properties_collector.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/transaction_log_impl.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/version_builder.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/version_edit.cc.o
+[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/version_set.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/wal_manager.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/write_batch.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/write_batch_base.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/write_controller.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/write_thread.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/env/env.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/env/env_chroot.cc.o
+[ 24%] Building CXX object CMakeFiles/rocksdb.dir/env/env_encryption.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/env/env_hdfs.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/env/mock_env.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/memtable/alloc_tracker.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/memtable/hash_cuckoo_rep.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/memtable/hash_linklist_rep.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/memtable/hash_skiplist_rep.cc.o
+[ 27%] Building CXX object CMakeFiles/rocksdb.dir/memtable/skiplistrep.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/memtable/vectorrep.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/memtable/write_buffer_manager.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/histogram.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/histogram_windowing.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/instrumented_mutex.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/iostats_context.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/perf_context.cc.o
+[ 31%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/perf_level.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/statistics.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_impl.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_updater.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_util.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_util_debug.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/options/cf_options.cc.o
+[ 34%] Building CXX object CMakeFiles/rocksdb.dir/options/db_options.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/options/options.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/options/options_helper.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/options/options_parser.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/options/options_sanity_check.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/port/stack_trace.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/table/adaptive_table_factory.cc.o
+[ 37%] Building CXX object CMakeFiles/rocksdb.dir/table/block.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based_filter_block.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based_table_builder.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based_table_factory.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based_table_reader.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_builder.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_fetcher.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/block_prefix_index.cc.o
+[ 41%] Building CXX object CMakeFiles/rocksdb.dir/table/bloom_block.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/cuckoo_table_builder.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/cuckoo_table_factory.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/cuckoo_table_reader.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/flush_block_policy.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/format.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/full_filter_block.cc.o
+[ 44%] Building CXX object CMakeFiles/rocksdb.dir/table/get_context.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/index_builder.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/iterator.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/merging_iterator.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/meta_blocks.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/partitioned_filter_block.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/persistent_cache_helper.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/plain_table_builder.cc.o
+[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/plain_table_factory.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/plain_table_index.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/plain_table_key_coding.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/plain_table_reader.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/sst_file_writer.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/table_properties.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/two_level_iterator.cc.o
+[ 51%] Building CXX object CMakeFiles/rocksdb.dir/tools/db_bench_tool.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/tools/dump/db_dump_tool.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/tools/ldb_cmd.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/tools/ldb_tool.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/tools/sst_dump_tool.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/util/arena.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/util/auto_roll_logger.cc.o
+[ 55%] Building CXX object CMakeFiles/rocksdb.dir/util/bloom.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/coding.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/compaction_job_stats_impl.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/comparator.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/concurrent_arena.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/crc32c.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/delete_scheduler.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/dynamic_bloom.cc.o
+[ 58%] Building CXX object CMakeFiles/rocksdb.dir/util/event_logger.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/file_reader_writer.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/file_util.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/filename.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/filter_policy.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/hash.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/log_buffer.cc.o
+[ 62%] Building CXX object CMakeFiles/rocksdb.dir/util/murmurhash.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/random.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/rate_limiter.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/slice.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/sst_file_manager_impl.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/status.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/status_message.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/string_util.cc.o
+[ 65%] Building CXX object CMakeFiles/rocksdb.dir/util/sync_point.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/testutil.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/thread_local.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/threadpool_imp.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/transaction_test_util.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/xxhash.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/utilities/backupable/backupable_db.cc.o
+[ 68%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_compaction_filter.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_db.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_db_impl.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_dump_tool.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_file.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_log_reader.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_log_writer.cc.o
+[ 72%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_log_format.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/ttl_extractor.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/cassandra/cassandra_compaction_filter.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/cassandra/format.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/cassandra/merge_operator.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/checkpoint/checkpoint_impl.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/col_buf_decoder.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/col_buf_encoder.cc.o
+[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/column_aware_encoding_util.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/date_tiered/date_tiered_db_impl.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/debug.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/document/document_db.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/document/json_document.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/document/json_document_builder.cc.o
+[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/env_mirror.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/env_timed.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/geodb/geodb_impl.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/leveldb_options/leveldb_options.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/lua/rocks_lua_compaction_filter.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/memory/memory_util.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/bytesxor.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/max.cc.o
+[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/put.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/string_append/stringappend.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/string_append/stringappend2.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/uint64add.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/option_change_migration/option_change_migration.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/options/options_util.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/block_cache_tier.cc.o
+[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/block_cache_tier_file.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/block_cache_tier_metadata.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/persistent_cache_tier.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/volatile_tier_impl.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/redis/redis_lists.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/simulator_cache/sim_cache.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/spatialdb/spatial_db.cc.o
+[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/table_properties_collectors/compact_on_deletion_collector.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/optimistic_transaction_db_impl.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/optimistic_transaction.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/pessimistic_transaction.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/pessimistic_transaction_db.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/snapshot_checker.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/transaction_base.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/transaction_db_mutex_impl.cc.o
+[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/transaction_lock_mgr.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/transaction_util.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/write_prepared_txn.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/write_prepared_txn_db.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/ttl/db_ttl_impl.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/write_batch_with_index/write_batch_with_index.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/write_batch_with_index/write_batch_with_index_internal.cc.o
+[ 96%] Building CXX object CMakeFiles/rocksdb.dir/port/port_posix.cc.o
+[100%] Building CXX object CMakeFiles/rocksdb.dir/env/env_posix.cc.o
+[100%] Building CXX object CMakeFiles/rocksdb.dir/env/io_posix.cc.o
+[100%] Linking CXX static library librocksdb.a
+github.com/cockroachdb/cockroach/vendor/github.com/armon/go-radix
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/paths
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/utilities
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/ttycolor
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/ast/astutil
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/go/printer
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/internal/fastwalk
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/stress
+github.com/cockroachdb/cockroach/vendor/github.com/client9/misspell
+github.com/cockroachdb/cockroach/vendor/github.com/Masterminds/semver
+github.com/cockroachdb/cockroach/vendor/github.com/Masterminds/vcs
+github.com/cockroachdb/cockroach/vendor/github.com/boltdb/bolt
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/proto
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/cmd/gofmt
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/imports
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/go/format
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/pkgtree
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/imports
+github.com/cockroachdb/cockroach/vendor/github.com/pkg/errors
+github.com/cockroachdb/cockroach/vendor/github.com/jmank88/nuts
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/fs
+github.com/cockroachdb/cockroach/vendor/github.com/nightlyone/lockfile
+github.com/cockroachdb/cockroach/vendor/github.com/sdboyer/constext
+github.com/cockroachdb/cockroach/vendor/golang.org/x/net/context
+github.com/cockroachdb/cockroach/vendor/github.com/pelletier/go-toml
+github.com/cockroachdb/cockroach/vendor/gopkg.in/yaml.v2
+github.com/cockroachdb/cockroach/vendor/golang.org/x/sync/errgroup
+github.com/cockroachdb/cockroach/vendor/github.com/client9/misspell/cmd/misspell
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/gcimporter15
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/crlfmt
+github.com/cockroachdb/cockroach/vendor/github.com/golang/glog
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/internal/pb
+github.com/cockroachdb/cockroach/vendor/github.com/cockroachdb/gostdlib/x/tools/cmd/goimports
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/generator/internal/remap
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/gcexportdata
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/plugin
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/httprule
+github.com/cockroachdb/cockroach/vendor/github.com/golang/lint
+github.com/cockroachdb/cockroach/vendor/google.golang.org/genproto/googleapis/api/annotations
+github.com/cockroachdb/cockroach/vendor/github.com/golang/protobuf/protoc-gen-go/generator
+github.com/cockroachdb/cockroach/vendor/github.com/jteeuwen/go-bindata
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/buildutil
+github.com/cockroachdb/cockroach/vendor/github.com/jteeuwen/go-bindata/go-bindata
+github.com/cockroachdb/cockroach/vendor/github.com/golang/lint/golint
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/go/loader
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/gotool/internal/load
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/gotool
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cover
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/errcheck/internal/errcheck
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/suffixtree
+github.com/cockroachdb/cockroach/vendor/github.com/mattn/goveralls
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/syntax
+github.com/cockroachdb/cockroach/vendor/github.com/wadey/gocovmerge
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/syntax/golang
+github.com/cockroachdb/cockroach/vendor/github.com/kisielk/errcheck
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/output
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl/job
+github.com/cockroachdb/cockroach/vendor/github.com/mibk/dupl
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/internal/stats
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/gps/verify
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/feedback
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/storage/benchfmt
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cmd/goyacc
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/benchstat
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep
+github.com/cockroachdb/cockroach/vendor/golang.org/x/tools/cmd/stringer
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/generator
+github.com/cockroachdb/cockroach/vendor/golang.org/x/perf/cmd/benchstat
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/gengateway
+github.com/cockroachdb/cockroach/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/base
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/glock
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/godep
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/glide
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/govend
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/govendor
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/gvt
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers/vndr
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/internal/importers
+github.com/cockroachdb/cockroach/vendor/github.com/golang/dep/cmd/dep
+touch bin/.bootstrap
+go install -v protoc-gen-gogoroach
+bin/prereqs ./pkg/cmd/protoc-gen-gogoroach > bin/protoc-gen-gogoroach.d.tmp
+mv -f bin/protoc-gen-gogoroach.d.tmp bin/protoc-gen-gogoroach.d
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/proto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/descriptor
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/plugin
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/gogoproto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/vanity
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/generator
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/testgen
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/defaultcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/embedcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/enumstringer
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/oneofcheck
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/marshalto
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/populate
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/unmarshal
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/protoc-gen-gogo/grpc
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/compare
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/description
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/face
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/stringer
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/equal
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/size
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/gostring
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/plugin/union
+github.com/cockroachdb/cockroach/vendor/github.com/gogo/protobuf/vanity/command
+github.com/cockroachdb/cockroach/pkg/cmd/protoc-gen-gogoroach
+find ./pkg -name node_modules -prune -o -type f -name '*.pb.go' -exec rm {} +
+set -e; for dir in ./pkg/acceptance/cluster/ ./pkg/build/ ./pkg/ccl/backupccl/ ./pkg/ccl/baseccl/ ./pkg/ccl/storageccl/engineccl/enginepbccl/ ./pkg/ccl/utilccl/licenseccl/ ./pkg/config/ ./pkg/gossip/ ./pkg/internal/client/ ./pkg/jobs/jobspb/ ./pkg/roachpb/ ./pkg/rpc/ ./pkg/server/diagnosticspb/ ./pkg/server/serverpb/ ./pkg/server/status/ ./pkg/settings/cluster/ ./pkg/sql/distsqlrun/ ./pkg/sql/pgwire/pgerror/ ./pkg/sql/sqlbase/ ./pkg/sql/stats/ ./pkg/storage/ ./pkg/storage/closedts/ctpb/ ./pkg/storage/engine/enginepb/ ./pkg/storage/storagebase/ ./pkg/ts/tspb/ ./pkg/util/ ./pkg/util/hlc/ ./pkg/util/log/ ./pkg/util/metric/ ./pkg/util/protoutil/ ./pkg/util/tracing/; do \
+build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --gogoroach_out=Mgoogle/api/annotations.proto=github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,,plugins=grpc,import_prefix=github.com/cockroachdb/cockroach/pkg/:./pkg $dir/*.proto; \
+done
+sed -i '/import _/d' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!import (fmt|math) "github.com/cockroachdb/cockroach/pkg/(fmt|math)"! !g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!github\.com/cockroachdb/cockroach/pkg/(etcd)!go.etcd.io/\1!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!cockroachdb/cockroach/pkg/(prometheus/client_model)!\1/go!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!github.com/cockroachdb/cockroach/pkg/(bytes|encoding/binary|errors|fmt|io|math|github\.com|(google\.)?golang\.org)!\1!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+sed -i -E 's!golang.org/x/net/context!context!g' ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+gofmt -s -w ./pkg/acceptance/cluster/testconfig.pb.go ./pkg/build/info.pb.go ./pkg/ccl/backupccl/backup.pb.go ./pkg/ccl/baseccl/encryption_options.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.pb.go ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.pb.go ./pkg/ccl/utilccl/licenseccl/license.pb.go ./pkg/config/system.pb.go ./pkg/config/zone.pb.go ./pkg/gossip/gossip.pb.go ./pkg/internal/client/lease.pb.go ./pkg/jobs/jobspb/jobs.pb.go ./pkg/roachpb/api.pb.go ./pkg/roachpb/app_stats.pb.go ./pkg/roachpb/data.pb.go ./pkg/roachpb/errors.pb.go ./pkg/roachpb/internal.pb.go ./pkg/roachpb/internal_raft.pb.go ./pkg/roachpb/io-formats.pb.go ./pkg/roachpb/metadata.pb.go ./pkg/rpc/heartbeat.pb.go ./pkg/server/diagnosticspb/diagnostics.pb.go ./pkg/server/serverpb/admin.pb.go ./pkg/server/serverpb/authentication.pb.go ./pkg/server/serverpb/init.pb.go ./pkg/server/serverpb/status.pb.go ./pkg/server/status/status.pb.go ./pkg/settings/cluster/cluster_version.pb.go ./pkg/sql/distsqlrun/api.pb.go ./pkg/sql/distsqlrun/data.pb.go ./pkg/sql/distsqlrun/processors.pb.go ./pkg/sql/distsqlrun/stats.pb.go ./pkg/sql/pgwire/pgerror/errors.pb.go ./pkg/sql/sqlbase/encoded_datum.pb.go ./pkg/sql/sqlbase/join_type.pb.go ./pkg/sql/sqlbase/privilege.pb.go ./pkg/sql/sqlbase/structured.pb.go ./pkg/sql/stats/histogram.pb.go ./pkg/storage/api.pb.go ./pkg/storage/closedts/ctpb/entry.pb.go ./pkg/storage/engine/enginepb/file_registry.pb.go ./pkg/storage/engine/enginepb/mvcc.pb.go ./pkg/storage/engine/enginepb/mvcc3.pb.go ./pkg/storage/engine/enginepb/rocksdb.pb.go ./pkg/storage/lease_status.pb.go ./pkg/storage/liveness.pb.go ./pkg/storage/log.pb.go ./pkg/storage/raft.pb.go ./pkg/storage/storagebase/proposer_kv.pb.go ./pkg/storage/storagebase/state.pb.go ./pkg/ts/tspb/timeseries.pb.go ./pkg/util/hlc/legacy_timestamp.pb.go ./pkg/util/hlc/timestamp.pb.go ./pkg/util/log/log.pb.go ./pkg/util/metric/metric.pb.go ./pkg/util/protoutil/clone.pb.go ./pkg/util/tracing/recorded_span.pb.go ./pkg/util/unresolved_addr.pb.go
+touch bin/.go_protobuf_sources
+find ./pkg -name node_modules -prune -o -type f -name '*.pb.gw.go' -exec rm {} +
+build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true,request_context=true:./pkg ./pkg/server/serverpb/admin.proto ./pkg/server/serverpb/status.proto ./pkg/server/serverpb/authentication.proto
+build/werror.sh /go/native/x86_64-pc-linux-gnu/protobuf/protoc -Ipkg:./vendor/github.com:./vendor/github.com/gogo/protobuf:./vendor/github.com/gogo/protobuf/protobuf:./vendor/go.etcd.io:./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true,request_context=true:./pkg ./pkg/ts/tspb/timeseries.proto
+sed -i -E 's!golang.org/x/net/context!context!g' ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+gofmt -s -w ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+goimports -w ./pkg/server/serverpb/admin.pb.gw.go ./pkg/server/serverpb/status.pb.gw.go ./pkg/server/serverpb/authentication.pb.gw.go ./pkg/ts/tspb/timeseries.pb.gw.go
+touch bin/.gw_protobuf_sources
+mkdir -p pkg/sql/parser/gen
+set -euo pipefail; \
+TYPES=$(awk '/func.*sqlSymUnion/ {print $(NF - 1)}' pkg/sql/parser/sql.y | sed -e 's/[]\/$*.^|[]/\\&/g' | tr '\n' '|' | sed -E '$s/.$//'); \
+sed -E "s_(type|token) <($TYPES)>_\1 <union> /* <\2> */_" < pkg/sql/parser/sql.y | \
+awk -f pkg/sql/parser/replace_help_rules.awk | \
+sed -Ee 's,//.*$,,g;s,/[*]([^*]|[*][^/])*[*]/, ,g;s/ +$//g' > pkg/sql/parser/gen/sql-gen.y.tmp || rm pkg/sql/parser/gen/sql-gen.y.tmp
+mv -f pkg/sql/parser/gen/sql-gen.y.tmp pkg/sql/parser/gen/sql-gen.y
+set -euo pipefail; \
+  ret=$(cd pkg/sql/parser/gen && goyacc -p sql -o sql.go.tmp sql-gen.y); \
+  if expr "$ret" : ".*conflicts" >/dev/null; then \
+    echo "$ret"; exit 1; \
+  fi
+(echo "// Code generated by goyacc. DO NOT EDIT."; \
+ echo "// GENERATED FILE DO NOT EDIT"; \
+ cat pkg/sql/parser/gen/sql.go.tmp | \
+ sed -E 's/^const ([A-Z][_A-Z0-9]*) =.*$/const \1 = lex.\1/g') > pkg/sql/parser/sql.go.tmp || rm pkg/sql/parser/sql.go.tmp
+mv -f pkg/sql/parser/sql.go.tmp pkg/sql/parser/sql.go
+goimports -w pkg/sql/parser/sql.go
+mv -f pkg/sql/parser/helpmap_test.go.tmp pkg/sql/parser/helpmap_test.go
+gofmt -s -w pkg/sql/parser/helpmap_test.go
+awk -f pkg/sql/parser/help.awk < pkg/sql/parser/sql.y > pkg/sql/parser/help_messages.go.tmp || rm pkg/sql/parser/help_messages.go.tmp
+mv -f pkg/sql/parser/help_messages.go.tmp pkg/sql/parser/help_messages.go
+gofmt -s -w pkg/sql/parser/help_messages.go
+(echo "// Code generated by make. DO NOT EDIT."; \
+ echo "// GENERATED FILE DO NOT EDIT"; \
+ echo; \
+ echo "package lex"; \
+ echo; \
+ grep '^const [A-Z][_A-Z0-9]* ' pkg/sql/parser/gen/sql.go.tmp) > pkg/sql/lex/tokens.go.tmp || rm pkg/sql/lex/tokens.go.tmp
+mv -f pkg/sql/lex/tokens.go.tmp pkg/sql/lex/tokens.go
+awk -f pkg/sql/parser/all_keywords.awk < pkg/sql/parser/sql.y > pkg/sql/lex/keywords.go.tmp || rm pkg/sql/lex/keywords.go.tmp
+mv -f pkg/sql/lex/keywords.go.tmp pkg/sql/lex/keywords.go
+gofmt -s -w pkg/sql/lex/keywords.go
+awk -f pkg/sql/parser/reserved_keywords.awk < pkg/sql/parser/sql.y > pkg/sql/lex/reserved_keywords.go.tmp || rm pkg/sql/lex/reserved_keywords.go.tmp
+mv -f pkg/sql/lex/reserved_keywords.go.tmp pkg/sql/lex/reserved_keywords.go
+gofmt -s -w pkg/sql/lex/reserved_keywords.go
+go install -v optgen
+bin/prereqs ./pkg/sql/opt/optgen/cmd/optgen > bin/optgen.d.tmp
+mv -f bin/optgen.d.tmp bin/optgen.d
+github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang
+github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/cmd/optgen
+optgen -out pkg/sql/opt/memo/expr.og.go exprs pkg/sql/opt/ops/*.opt
+optgen -out pkg/sql/opt/operator.og.go ops pkg/sql/opt/ops/*.opt
+optgen -out pkg/sql/opt/xform/explorer.og.go explorer pkg/sql/opt/ops/*.opt pkg/sql/opt/xform/rules/*.opt
+optgen -out pkg/sql/opt/norm/factory.og.go factory pkg/sql/opt/ops/*.opt pkg/sql/opt/norm/rules/*.opt
+optgen -out pkg/sql/opt/rule_name.og.go rulenames pkg/sql/opt/ops/*.opt pkg/sql/opt/norm/rules/*.opt pkg/sql/opt/xform/rules/*.opt
+stringer -output=pkg/sql/opt/rule_name_string.go -type=RuleName pkg/sql/opt/rule_name.go pkg/sql/opt/rule_name.og.go
+go test -race -tags ' make x86_64_pc_linux_gnu' -ldflags '-X github.com/cockroachdb/cockroach/pkg/build.typ=development -extldflags "" -X "github.com/cockroachdb/cockroach/pkg/build.tag=v2.2.0-alpha.00000000-925-g3baa3d9" -X "github.com/cockroachdb/cockroach/pkg/build.rev=3baa3d9b299a392b7d9b737dbfb333d095e672a9" -X "github.com/cockroachdb/cockroach/pkg/build.cgoTargetTriple=x86_64-pc-linux-gnu"  ' -run "."  -timeout 45m ./pkg/util/failsuite/... -v -json
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestThatPasses' captureStandardOutput='true']
+=== RUN   TestThatPasses
+output of TestThatPasses
+--- PASS: TestThatPasses (0.00s)
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestThatPasses' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestThatFails' captureStandardOutput='true']
+=== RUN   TestThatFails
+--- FAIL: TestThatFails (0.00s)
+	main_test.go:41: an error occurs
+	main_test.go:42: then the test fatals
+##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestThatFails' details='']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestThatFails' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestThatGetsSkipped' captureStandardOutput='true']
+=== RUN   TestThatGetsSkipped
+--- SKIP: TestThatGetsSkipped (0.00s)
+	main_test.go:46: logging something
+	main_test.go:47: skipped
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestThatGetsSkipped']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/8' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/8
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/8
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/8
+==================
+WARNING: DATA RACE
+Write at 0x00c42009e3a5 by goroutine 28:
+  github.com/cockroachdb/cockroach/pkg/util/failsuite.testParallelImpl.func2()
+      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:73 +0x6e
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:777 +0x16d
+
+Previous write at 0x00c42009e3a5 by goroutine 14:
+  github.com/cockroachdb/cockroach/pkg/util/failsuite.testParallelImpl.func2()
+      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:73 +0x6e
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:777 +0x16d
+
+Goroutine 28 (running) created at:
+  testing.(*T).Run()
+      /usr/local/go/src/testing/testing.go:824 +0x564
+  github.com/cockroachdb/cockroach/pkg/util/failsuite.testParallelImpl()
+      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:70 +0x111
+  github.com/cockroachdb/cockroach/pkg/util/failsuite.TestParallelOneWithDataRaceWithoutFailures()
+      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:51 +0x3d
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:777 +0x16d
+
+Goroutine 14 (running) created at:
+  testing.(*T).Run()
+      /usr/local/go/src/testing/testing.go:824 +0x564
+  github.com/cockroachdb/cockroach/pkg/util/failsuite.testParallelImpl()
+      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:70 +0x111
+  github.com/cockroachdb/cockroach/pkg/util/failsuite.TestParallelOneWithDataRaceWithoutFailures()
+      /go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/main_test.go:51 +0x3d
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:777 +0x16d
+==================
+FAIL	github.com/cockroachdb/cockroach/pkg/util/failsuite	0.019s
+##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/8' message='Race detected!' details='']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/8' duration='20']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestZPanics' captureStandardOutput='true']
+=== RUN   TestZPanics
+first output something
+--- FAIL: TestZPanics (0.00s)
+	main_test.go:35: then log something
+	main_test.go:36: an error, why not
+panic: boom [recovered]
+	panic: boom
+
+goroutine 20 [running]:
+testing.tRunner.func1(0xc4200ea1e0)
+	/usr/local/go/src/testing/testing.go:742 +0x567
+panic(0x5b7860, 0x609a90)
+	/usr/local/go/src/runtime/panic.go:502 +0x24a
+github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic.TestZPanics(0xc4200ea1e0)
+	/go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic/main_test.go:37 +0x14b
+testing.tRunner(0xc4200ea1e0, 0x5f8dd8)
+	/usr/local/go/src/testing/testing.go:777 +0x16e
+created by testing.(*T).Run
+	/usr/local/go/src/testing/testing.go:824 +0x565
+
+goroutine 1 [chan receive]:
+testing.(*T).Run(0xc4200ea0f0, 0x5f0e98, 0xb, 0x5f8dd8, 0xc420069c38)
+	/usr/local/go/src/testing/testing.go:825 +0x597
+testing.runTests.func1(0xc4200ea0f0)
+	/usr/local/go/src/testing/testing.go:1063 +0xa5
+testing.tRunner(0xc4200ea0f0, 0xc420069d80)
+	/usr/local/go/src/testing/testing.go:777 +0x16e
+testing.runTests(0xc4200b0340, 0x6dda60, 0x1, 0x1, 0x0)
+	/usr/local/go/src/testing/testing.go:1061 +0x4e2
+testing.(*M).Run(0xc4200ec000, 0x0)
+	/usr/local/go/src/testing/testing.go:978 +0x2ce
+github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic.TestMain(0xc4200ec000)
+	/go/src/github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic/main_test.go:30 +0x60
+main.main()
+	_testmain.go:40 +0x22b
+FAIL	github.com/cockroachdb/cockroach/pkg/util/failsuite/failsuitepanic	0.014s
+##teamcity[testFailed timestamp='2017-01-02T04:05:06.789' name='TestZPanics' details='']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestZPanics' duration='14']
+make: *** [testrace] Error 1
+Makefile:830: recipe for target 'testrace' failed
+
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures
+output before calling t.Parallel()
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures
+=== CONT  TestParallelOneWithDataRaceWithoutFailures
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/0' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/0
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/0
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/0' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/0' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/1' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/1
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/1
+=== CONT  TestParallelOneWithDataRaceWithoutFailures/1
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/1' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/1' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/2' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/2
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/2
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/2' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/2' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/3' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/3
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/3
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/3' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/3' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/4' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/4
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/4
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/4' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/4' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/5' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/5
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/5
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/5' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/5' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/6' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/6
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/6
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/6' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/6' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/7' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/7
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/7
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/7' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/7' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/9' captureStandardOutput='true']
+=== RUN   TestParallelOneWithDataRaceWithoutFailures/9
+=== PAUSE TestParallelOneWithDataRaceWithoutFailures/9
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/9' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelOneWithDataRaceWithoutFailures/9' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures
+output before calling t.Parallel()
+=== PAUSE TestParallelWithDataRaceAndFailures
+=== CONT  TestParallelWithDataRaceAndFailures
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/0' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/0
+=== PAUSE TestParallelWithDataRaceAndFailures/0
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/0' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/0' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/1' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/1
+=== PAUSE TestParallelWithDataRaceAndFailures/1
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/1' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/1' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/2' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/2
+=== PAUSE TestParallelWithDataRaceAndFailures/2
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/2' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/2' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/3' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/3
+=== PAUSE TestParallelWithDataRaceAndFailures/3
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/3' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/3' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/4' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/4
+=== PAUSE TestParallelWithDataRaceAndFailures/4
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/4' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/4' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/5' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/5
+=== PAUSE TestParallelWithDataRaceAndFailures/5
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/5' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/5' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/6' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/6
+=== PAUSE TestParallelWithDataRaceAndFailures/6
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/6' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/6' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/7' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/7
+=== PAUSE TestParallelWithDataRaceAndFailures/7
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/7' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/7' duration='0']
+##teamcity[testStarted timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/8' captureStandardOutput='true']
+=== RUN   TestParallelWithDataRaceAndFailures/8
+(test not terminated explicitly)
+##teamcity[testIgnored timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/8' message='Test framework exited prematurely. Likely another test panicked or encountered a data race']
+##teamcity[testFinished timestamp='2017-01-02T04:05:06.789' name='TestParallelWithDataRaceAndFailures/8' duration='0']


### PR DESCRIPTION
This executes on the plan outlined in:

https://github.com/cockroachdb/go-test-teamcity/issues/5#issuecomment-422494665

by making go-test-teamcity take test2json input. More precisely, and
unfortunately, it realistically has to be taking the input of

    make test TESTFLAGS='-v -json'

which isn't pure JSON but contains a bunch of `make` and `go build`
output (requiring a bit of massaging to pluck the relevant JSON from
the input stream).

I retained the old functionality and introduced a new `-json` flag
that triggers the new code. This important because our CI scripts
are versioned, and so we need the updated code here to work with
the non-updated CI pipeline.

I initially tried to jsonify the old test cases, but they're basically
garbage and don't correspond to real test output in some cases. Instead,
I generated a new corpus from actual CI runs in the main repo from which
I copied the artifacts file:

https://github.com/cockroachdb/cockroach/pull/30406

I think it's worth checking in that PR in suitable form because it'll
allow us to iterate on this parser and extend the corpus much more
easily in the future.

Two caveats:

1. the code isn't creating TeamCity Test Suite tags. I was never married
to those and have found it unfortunate that they mess up TeamCity's test
duration counting (as far as I can remember). Adding them is probably
possible, but with parallel tests (which we don't use heavily) and such
I'm pretty sure that any naive implementation would be incorrect.
2. Tests which aren't explicitly ended (due to premature exit/crash of
the package test binary) are now output at the very end of the log.
Since the input contains *all tests*, this can be a little unintuitive.
However, these final tests contain basically no information anyway, so
that seems fine. This could be improved by flushing out the tests
whenever a package-level PASS/FAIL event is encountered, but I'm not
sure it's worth doing so.

The next step, assuming the code is in good order, is to merge it and
update the CI pipeline in the main repo to pass the `-json` flags both
to `go test` and `go-test-teamcity`.