### PR TITLE
Compatibility with go1.9

### DIFF
--- a/main.go
+++ b/main.go
@@ -251,7 +251,10 @@ func processJSON(r *bufio.Reader, w io.Writer) {
 	}()
 
 	dec := json.NewDecoder(r)
-	dec.DisallowUnknownFields()
+	// This needs Go 1.10+, which we don't have on TeamCity at the
+	// time of writing.
+	//
+	// dec.DisallowUnknownFields()
 
 	for dec.More() {
 		var event TestEvent


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/pull/30453 for context.